### PR TITLE
Force editor destruction.

### DIFF
--- a/src/main/kotlin/com/dprint/services/DprintService.kt
+++ b/src/main/kotlin/com/dprint/services/DprintService.kt
@@ -75,7 +75,7 @@ class DprintService(private val project: Project) {
         }
 
         AppExecutorUtil.getAppExecutorService().submit {
-            if (this.editorServiceProcess?.isAlive == true) {
+            if (this.editorServiceProcess != null) {
                 this.destroyEditorService()
             }
 


### PR DESCRIPTION
## Overview

In tracking down an issue with formatting I have found that if the editor service hangs it doesn't get destroyed like I intended it to. This adds a more forceful condition so we actually destroy it when it has hung.