### PR TITLE
Better description and action menu name fix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To use this plugin:
   - If your config file isn't at the base of your project, provide the absolute path to your config in the "Dprint configuration json file location" field, otherwise it will be detected automatically.
   - If dprint isn't on your path, provide the absolute path to the dprint executable in the "Dprint executable location" field, otherwise it will be detected automatically.
   - To run dprint on save tick the "Run dprint formatter on save" config checkbox.
-- Use the "Reformat with Dprint" action (Alt-Shift-Cmd-D on macOS or Alt-Shift-Ctrl-D on Windows and Linux) or find it using the "Find Action" popup (Cmd/Ctrl-Shift-A)
+- Use the "Reformat with dprint" action (Alt-Shift-Cmd-D on macOS or Alt-Shift-Ctrl-D on Windows and Linux) or find it using the "Find Action" popup (Cmd/Ctrl-Shift-A)
 
 This plugin uses a long running process known as the `editor-service`. If you change your `dprint.json` file or dprint is not formatting as expected, in `Preferences` -> `Tools` -> `Dprint` click the `Reload` button. This will force the editor service to close down and reload.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,20 @@
 # dprint-intellij-plugin
 
 <!-- Plugin description -->
-A dprint plugin for Intellij. Formats code using the dprint CLI.
+This plugin adds support for dprint, a flexible and extensible code formatter ([dprint.dev](https://dprint.dev/)).
+
+To use this plugin:
+- Install and configure dprint for your repository, [dprint.dev/setup](https://dprint.dev/setup/)
+- Configure this plugin at `Preferences` -> `Tools` -> `Dprint`.
+  - Ensure `Enable Dprint` is checked
+  - If your config file isn't at the base of your project, provide the absolute path to your config in the "Dprint configuration json file location" field, otherwise it will be detected automatically.
+  - If dprint isn't on your path, provide the absolute path to the dprint executable in the "Dprint executable location" field, otherwise it will be detected automatically.
+  - To run dprint on save tick the "Run dprint formatter on save" config checkbox.
+- Use the "Reformat with Dprint" action (Alt-Shift-Cmd-D on macOS or Alt-Shift-Ctrl-D on Windows and Linux) or find it using the "Find Action" popup (Cmd/Ctrl-Shift-A)
+
+This plugin uses a long running process known as the `editor-service`. If you change your `dprint.json` file or dprint is not formatting as expected, in `Preferences` -> `Tools` -> `Dprint` click the `Reload` button. This will force the editor service to close down and reload.
+
+Please report any issues with this Intellij plugin to the [github repository](https://github.com/dprint/dprint-intellij/issues).
 <!-- Plugin description end -->
 
 ## Installation

--- a/src/main/resources/messages/Bundle.properties
+++ b/src/main/resources/messages/Bundle.properties
@@ -36,5 +36,5 @@ formatting.sending.to.editor.service=Sending to editor service: {0}.
 formatting.sending.success.to.editor.service=Sending success to editor service.
 formatting.received.success=Received success bytes.
 formatting.received.value=Received value: {0}
-action.com.canva.dprint.actions.ReformatAction.text=Reformat with Dprint
-action.com.canva.dprint.actions.ReformatAction.description=Reformat with dprint
+action.com.dprint.actions.ReformatAction.text=Reformat with dprint
+action.com.dprint.actions.ReformatAction.description=Reformat with dprint


### PR DESCRIPTION
I took inspiration form the [prettier plugin](https://plugins.jetbrains.com/plugin/10456-prettier) developed by jetbrains themselves.

Also as its not obvious, this text gets patched into the plugin.xml on build via the `gradle-changelog-plugin` as per [this](https://github.com/JetBrains/intellij-platform-plugin-template#gradle-configuration)

The action menu name fix ensures we get this be named correctly.

![Screen Shot 2022-01-04 at 11 59 20 am](https://user-images.githubusercontent.com/7344652/147996165-234216d0-5852-4c3c-a6ac-276480a29443.png)