### PR TITLE
Fix versioning to allow for 2021.3.x installs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # dprint-intellij-plugin Changelog
 
 ## [Unreleased]
+- Fix versioning to allow for 2021.3.x installs
 
 ## [0.3.0]
 - Introduced support for v5 of the dprint schema

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,10 +2,10 @@
 # -> https://plugins.jetbrains.com/docs/intellij/intellij-artifacts.html
 pluginGroup=com.dprint.intellij.plugin
 pluginName=dprint-intellij-plugin
-pluginVersion=0.3.0
+pluginVersion=0.3.1
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild=213.*
+pluginSinceBuild=213
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.
 pluginVerifierIdeVersions=2021.3,2022.1


### PR DESCRIPTION
The intellij compatibility range wasn't quite right for the new version as we can support 2021.3.x. I asked on the forums and apparently the wildcard in the `sinceBuild` field was causing the issue. 

<img width="986" alt="Screen Shot 2022-05-19 at 9 27 31 pm" src="https://user-images.githubusercontent.com/7344652/169282975-3067ea7f-a45b-4c7e-9a2b-8a19b7860a36.png">
