### PR TITLE
Fix performance issue where stderr reader was not blocking.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## [Unreleased]
 - Performance improvements
+- Invalidate cache on restart
 
 ## [0.3.6]
 - Fix issue where using the IntelliJ formatter would result in a no-op on every second format, IntelliJ is reporting larger formatting ranges that content length and dprint would not format these files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # dprint-intellij-plugin Changelog
 
 ## [Unreleased]
+- Performance improvements
 
 ## [0.3.6]
 - Fix issue where using the IntelliJ formatter would result in a no-op on every second format, IntelliJ is reporting larger formatting ranges that content length and dprint would not format these files

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # -> https://plugins.jetbrains.com/docs/intellij/intellij-artifacts.html
 pluginGroup=com.dprint.intellij.plugin
 pluginName=dprint-intellij-plugin
-pluginVersion=0.3.6
+pluginVersion=0.3.7
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild=213

--- a/src/main/kotlin/com/dprint/services/editorservice/EditorServiceManager.kt
+++ b/src/main/kotlin/com/dprint/services/editorservice/EditorServiceManager.kt
@@ -12,6 +12,7 @@ import com.intellij.execution.util.ExecUtil
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.progress.BackgroundTaskQueue
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.Task
@@ -130,7 +131,7 @@ class EditorServiceManager(private val project: Project) {
             {
                 editorService?.canFormat(path) {
                     canFormatCache[path] = it
-                    LogUtils.info("Dprint: $path ${if (it) "can" else "cannot"} be formatted", project, LOGGER)
+                    LogUtils.info("$path ${if (it) "can" else "cannot"} be formatted", project, LOGGER)
                 }
             },
             true
@@ -214,6 +215,10 @@ class EditorServiceManager(private val project: Project) {
         // TODO rather than restarting we should try and see if it is healthy, cancel the pending format, and drain
         //  pending messages if we are on schema version 5
         maybeInitialiseEditorService()
+        clearCanFormatCache()
+        for (virtualFile in FileEditorManager.getInstance(project).openFiles) {
+            primeCanFormatCacheForFile(virtualFile)
+        }
     }
 
     fun destroyEditorService() {

--- a/src/main/kotlin/com/dprint/services/editorservice/v5/StdoutListener.kt
+++ b/src/main/kotlin/com/dprint/services/editorservice/v5/StdoutListener.kt
@@ -3,7 +3,6 @@ package com.dprint.services.editorservice.v5
 import com.dprint.core.Bundle
 import com.dprint.services.editorservice.EditorProcess
 import com.intellij.openapi.diagnostic.logger
-import org.apache.lucene.util.ThreadInterruptedException
 import java.nio.BufferUnderflowException
 
 private const val SLEEP_TIME = 500L
@@ -21,7 +20,7 @@ class StdoutListener(private val editorProcess: EditorProcess, private val pendi
             }
             try {
                 handleStdout()
-            } catch (e: ThreadInterruptedException) {
+            } catch (e: InterruptedException) {
                 LOGGER.info(e)
                 return
             } catch (e: BufferUnderflowException) {


### PR DESCRIPTION
## Overview

I missed something I should have removed after testing the weird IntelliJ behaviour in the last release. Basically, I had a thread running that was never blocking so it would eat up a whole process. This fixes that so that the stderr reader for the editor service blocks waiting for input, this will ensure the thread is only run when there is something to read.

I have also made a change to ensure the can format cache is cleared and repopulated after a restart.