### PR TITLE
Fix issue causing IntelliJ shutdown hang.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # dprint-intellij-plugin Changelog
 
 ## [Unreleased]
+- Fix issue causing IntelliJ to hang on shutdown
 
 ## [0.3.7]
 - Performance improvements

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # -> https://plugins.jetbrains.com/docs/intellij/intellij-artifacts.html
 pluginGroup=com.dprint.intellij.plugin
 pluginName=dprint-intellij-plugin
-pluginVersion=0.3.7
+pluginVersion=0.3.8
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild=213

--- a/src/main/kotlin/com/dprint/services/editorservice/EditorProcess.kt
+++ b/src/main/kotlin/com/dprint/services/editorservice/EditorProcess.kt
@@ -16,7 +16,6 @@ import kotlin.concurrent.thread
 private const val BUFFER_SIZE = 1024
 private const val ZERO = 0
 private const val U32_BYTE_SIZE = 4
-private const val SLEEP_TIME = 500L
 
 private val LOGGER = logger<EditorProcess>()
 
@@ -79,9 +78,10 @@ class EditorProcess(private val project: Project) {
                 } catch (e: BufferUnderflowException) {
                     // Happens when the editor service is shut down while this thread is waiting to read output
                     LOGGER.info(e)
+                    return@Runnable
                 } catch (e: Exception) {
                     LogUtils.error("Dprint: stderr reader failed", e, project, LOGGER)
-                    Thread.sleep(SLEEP_TIME)
+                    return@Runnable
                 }
             }
         }


### PR DESCRIPTION
The stderr reader was causing shutdown hangs, this ensures that if an error is thrown we shut it down