### PR TITLE
Support 2022.2, automatically detect node modules installs, and fix windows config issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 # dprint-intellij-plugin Changelog
 
 ## [Unreleased]
+- Fix issue where windows systems reported invalid executables
+- Add automatic node module detection from the base project path
+- Add 2022.2 to supported versions
 
 ## [0.3.8]
 - Fix issue causing IntelliJ to hang on shutdown

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 # dprint-intellij-plugin
 
 <!-- Plugin description -->
-This plugin adds support for dprint, a flexible and extensible code formatter ([dprint.dev](https://dprint.dev/)).
+This plugin adds support for dprint, a flexible and extensible code formatter ([dprint.dev](https://dprint.dev/)). It is in active early development, please report bugs and feature requests to the our [github](https://github.com/dprint/dprint-intellij/issues).
 
 To use this plugin:
 - Install and configure dprint for your repository, [dprint.dev/setup](https://dprint.dev/setup/)
 - Configure this plugin at `Preferences` -> `Tools` -> `Dprint`.
   - Ensure `Enable Dprint` is checked
   - If your config file isn't at the base of your project, provide the absolute path to your config in the "Dprint configuration json file location" field, otherwise it will be detected automatically.
-  - If dprint isn't on your path, provide the absolute path to the dprint executable in the "Dprint executable location" field, otherwise it will be detected automatically.
+  - If dprint isn't on your path, provide the absolute path to the dprint executable in the "Dprint executable location" field, otherwise it will be detected automatically from your path or a node modules at the project base path.
   - To run dprint on save tick the "Run dprint formatter on save" config checkbox.
 - Use the "Reformat with dprint" action by using the "Find Action" popup (<kbd>Cmd/Ctrl+Shift+A</kbd>).
-- Output from the plugin will be displayed in the Dprint tool window. This includes any syntax errors that may be stopping your file from being formatted.
+- Output from the plugin will be displayed in the Dprint tool window. This includes config errors and any syntax errors that may be stopping your file from being formatted.
 
 If a file can be formatted via dprint, the default IntelliJ formatter will be overridden and dprint will be run in its place when using <kbd>Option+Shift+Cmd+L</kbd> on macOS or <kbd>Alt+Shift+Ctrl+L</kbd> on Windows and Linux.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # dprint-intellij-plugin
 
 <!-- Plugin description -->
-This plugin adds support for dprint, a flexible and extensible code formatter ([dprint.dev](https://dprint.dev/)). It is in active early development, please report bugs and feature requests to the our [github](https://github.com/dprint/dprint-intellij/issues).
+This plugin adds support for dprint, a flexible and extensible code formatter ([dprint.dev](https://dprint.dev/)). It is in active early development, please report bugs and feature requests to our [github](https://github.com/dprint/dprint-intellij/issues).
 
 To use this plugin:
 - Install and configure dprint for your repository, [dprint.dev/setup](https://dprint.dev/setup/)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,6 +40,8 @@ intellij {
     version.set(properties("platformVersion"))
     type.set(properties("platformType"))
     downloadSources.set(properties("platformDownloadSources").toBoolean())
+    // Ensures all new builds will "just work" without an update. Obtained from thread in IntelliJ slack
+    updateSinceUntilBuild.set(false)
 
     // Plugin Dependencies. Uses `platformPlugins` property from the gradle.properties file.
     plugins.set(properties("platformPlugins").split(',').map(String::trim).filter(String::isNotEmpty))

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,15 +2,15 @@
 # -> https://plugins.jetbrains.com/docs/intellij/intellij-artifacts.html
 pluginGroup=com.dprint.intellij.plugin
 pluginName=dprint-intellij-plugin
-pluginVersion=0.3.8
+pluginVersion=0.3.9
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild=213
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.
-pluginVerifierIdeVersions=2021.3,2022.1
+pluginVerifierIdeVersions=2021.3,2022.1,2022.2
 platformType=IU
-platformVersion=2022.1
+platformVersion=2022.2
 platformDownloadSources=true
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22

--- a/src/main/kotlin/com/dprint/core/FileUtils.kt
+++ b/src/main/kotlin/com/dprint/core/FileUtils.kt
@@ -90,7 +90,7 @@ object FileUtils {
     }
 
     /**
-     * Validates a path ends with 'dprint' pr 'dprint.exe' and is executable
+     * Validates a path ends with 'dprint' or 'dprint.exe' and is executable
      */
     fun validateExecutablePath(path: String): Boolean {
         return path.endsWith(getExecutableFile()) && File(path).canExecute()

--- a/src/main/kotlin/com/dprint/core/FileUtils.kt
+++ b/src/main/kotlin/com/dprint/core/FileUtils.kt
@@ -90,10 +90,10 @@ object FileUtils {
     }
 
     /**
-     * Validates a path ends with 'dprint' and is executable
+     * Validates a path ends with 'dprint' pr 'dprint.exe' and is executable
      */
     fun validateExecutablePath(path: String): Boolean {
-        return path.endsWith("dprint") && File(path).canExecute()
+        return path.endsWith(getExecutableFile()) && File(path).canExecute()
     }
 
     /**
@@ -118,6 +118,24 @@ object FileUtils {
     }
 
     /**
+     * Attempts to get the dprint executable location by checking node modules
+     */
+    private fun getLocationFromTheNodeModules(basePath: String?): String? {
+        basePath?.let {
+            val path = "$it/node_modules/dprint/${getExecutableFile()}"
+            if (validateExecutablePath(path)) return path
+        }
+        return null
+    }
+
+    private fun getExecutableFile(): String {
+        return when (System.getProperty("os.name").lowercase().contains("win")) {
+            true -> "dprint.exe"
+            false -> "dprint"
+        }
+    }
+
+    /**
      * Gets a valid dprint executable path. It will try to use the configured path and will fall
      * back to a path that is discoverable via the command line
      *
@@ -134,8 +152,11 @@ object FileUtils {
         }
 
         project.basePath?.let { workingDirectory ->
-            getLocationFromThePath(workingDirectory)?.let { executablePath ->
-                return executablePath
+            getLocationFromTheNodeModules(project.basePath)?.let {
+                return it
+            }
+            getLocationFromThePath(workingDirectory)?.let {
+                return it
             }
         }
 


### PR DESCRIPTION
## Overview

This fixes a config issue on windows systems, I was only considering the `dprint` executable to be valid, not `dprint.exe`. That should be fixed now.

There was a thread on the IntelliJ slack about auto supporting new versions, it seems the gradle plugin changed and I had to turn on compatibility inferrence.

There was some feedback on the plugin page on the Jetbrains marketplace [here](https://plugins.jetbrains.com/plugin/18192-dprint). That is where the windows bug came from and I have added support for automatic node modules installs.