### PR TITLE
Handle scratch files and run format after eslint fixes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 # dprint-intellij-plugin Changelog
 
 ## [Unreleased]
+- Run dprint after Eslint fixes have been applied
+- Ensure dprint doesn't attempt to check/format scratch files (perf optimisation)
 
 ## [0.3.9]
 - Fix issue where windows systems reported invalid executables

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # -> https://plugins.jetbrains.com/docs/intellij/intellij-artifacts.html
 pluginGroup=com.dprint.intellij.plugin
 pluginName=dprint-intellij-plugin
-pluginVersion=0.3.9
+pluginVersion=0.3.10.beta.1
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild=213
@@ -14,7 +14,7 @@ platformVersion=2022.2
 platformDownloadSources=true
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
-platformPlugins=
+platformPlugins=JavaScriptLanguage
 # Opt-out flag for bundling Kotlin standard library.
 # See https://plugins.jetbrains.com/docs/intellij/kotlin.html#kotlin-standard-library for details.
 kotlin.stdlib.default.dependency=false

--- a/src/main/kotlin/com/dprint/listeners/FileOpenedListener.kt
+++ b/src/main/kotlin/com/dprint/listeners/FileOpenedListener.kt
@@ -2,6 +2,7 @@ package com.dprint.listeners
 
 import com.dprint.config.ProjectConfiguration
 import com.dprint.services.editorservice.EditorServiceManager
+import com.intellij.ide.scratch.ScratchUtil
 import com.intellij.openapi.components.service
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.fileEditor.FileEditorManagerListener
@@ -15,9 +16,10 @@ class FileOpenedListener : FileEditorManagerListener {
     override fun fileOpened(source: FileEditorManager, file: VirtualFile) {
         super.fileOpened(source, file)
 
-        if (!source.project.service<ProjectConfiguration>().state.enabled) {
-            return
-        }
+        if (!source.project.service<ProjectConfiguration>().state.enabled) return
+
+        // We ignore scratch files as they are never part of config
+        if (ScratchUtil.isScratch(file)) return
 
         val manager = source.project.service<EditorServiceManager>()
         manager.primeCanFormatCacheForFile(file)

--- a/src/main/kotlin/com/dprint/services/FormatterService.kt
+++ b/src/main/kotlin/com/dprint/services/FormatterService.kt
@@ -3,10 +3,12 @@ package com.dprint.services
 import com.dprint.core.Bundle
 import com.dprint.services.editorservice.EditorServiceManager
 import com.dprint.services.editorservice.FormatResult
+import com.intellij.ide.scratch.ScratchUtil
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.editor.Document
+import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.project.Project
 
 /**
@@ -17,12 +19,12 @@ class FormatterService(private val project: Project) {
     private var editorServiceManager = project.service<EditorServiceManager>()
 
     /**
-     * Attempts to format and save a virtual file using Dprint.
+     * Attempts to format and save a Document using Dprint.
      */
     fun format(filePath: String, document: Document) {
         val content = document.text
-
-        if (content.isBlank()) return
+        val virtualFile = FileDocumentManager.getInstance().getFile(document)
+        if (content.isBlank() || ScratchUtil.isScratch(virtualFile)) return
 
         if (editorServiceManager.canFormatCached(filePath) == true) {
             val formatHandler: (FormatResult) -> Unit = {

--- a/src/main/kotlin/com/dprint/services/editorservice/EditorServiceManager.kt
+++ b/src/main/kotlin/com/dprint/services/editorservice/EditorServiceManager.kt
@@ -9,6 +9,7 @@ import com.dprint.services.editorservice.v4.EditorServiceV4
 import com.dprint.services.editorservice.v5.EditorServiceV5
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.util.ExecUtil
+import com.intellij.ide.scratch.ScratchUtil
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.logger
@@ -87,10 +88,12 @@ class EditorServiceManager(private val project: Project) {
                     schemaVersion == null -> project.messageBus.syncPublisher(DprintMessage.DPRINT_MESSAGE_TOPIC).info(
                         Bundle.message("config.dprint.schemaVersion.not.found")
                     )
+
                     schemaVersion < SCHEMA_V4 -> project.messageBus.syncPublisher(DprintMessage.DPRINT_MESSAGE_TOPIC)
                         .info(
                             Bundle.message("config.dprint.schemaVersion.older")
                         )
+
                     schemaVersion == SCHEMA_V4 -> editorService = project.service<EditorServiceV4>()
                     schemaVersion == SCHEMA_V5 -> editorService = project.service<EditorServiceV5>()
                     schemaVersion > SCHEMA_V5 -> LogUtils.info(
@@ -217,7 +220,9 @@ class EditorServiceManager(private val project: Project) {
         maybeInitialiseEditorService()
         clearCanFormatCache()
         for (virtualFile in FileEditorManager.getInstance(project).openFiles) {
-            primeCanFormatCacheForFile(virtualFile)
+            if (!ScratchUtil.isScratch(virtualFile)) {
+                primeCanFormatCacheForFile(virtualFile)
+            }
         }
     }
 

--- a/src/main/resources/META-INF/javascript-config.xml
+++ b/src/main/resources/META-INF/javascript-config.xml
@@ -1,0 +1,7 @@
+<idea-plugin require-restart="true">
+    <extensions defaultExtensionNs="com.intellij">>
+        <actionOnSave id="DprintActionOnSave"
+                      implementation="com.dprint.listeners.OnSaveAction"
+                      order="after FormatOnSaveAction, after ESLintActionOnSave"/>
+    </extensions>
+</idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -5,6 +5,7 @@
 
     <!-- Product and plugin compatibility requirements -->
     <!-- https://plugins.jetbrains.com/docs/intellij/plugin-compatibility.html -->
+    <depends optional="true" config-file="./javascript-config.xml">JavaScript</depends>
     <depends>com.intellij.modules.platform</depends>
 
     <resource-bundle>messages.Bundle</resource-bundle>


### PR DESCRIPTION
## Overview

This ensures format happens after eslint fixes for platforms that have the Javascript plugin installed. Also it ensures that scratch files are never formatted as a performance optimisation. Scratch files are always brand new files that live outside the project hierarchy so they will never be formatted.