### PR TITLE
Better scratch file handling with logging.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # -> https://plugins.jetbrains.com/docs/intellij/intellij-artifacts.html
 pluginGroup=com.dprint.intellij.plugin
 pluginName=dprint-intellij-plugin
-pluginVersion=0.3.10.beta.1
+pluginVersion=0.3.10.beta.2
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild=213

--- a/src/main/kotlin/com/dprint/actions/ReformatAction.kt
+++ b/src/main/kotlin/com/dprint/actions/ReformatAction.kt
@@ -47,7 +47,7 @@ class ReformatAction : AnAction() {
         val formatterService = project.service<FormatterService>()
         PsiDocumentManager.getInstance(project).getPsiFile(document)?.virtualFile?.let { virtualFile ->
             LogUtils.info(Bundle.message("reformat.action.run", virtualFile.path), project, LOGGER)
-            formatterService.format(virtualFile.path, document)
+            formatterService.format(virtualFile, document)
         }
     }
 
@@ -55,7 +55,7 @@ class ReformatAction : AnAction() {
         val formatterService = project.service<FormatterService>()
         LogUtils.info(Bundle.message("reformat.action.run", virtualFile.path), project, LOGGER)
         getDocument(project, virtualFile)?.let {
-            formatterService.format(virtualFile.path, it)
+            formatterService.format(virtualFile, it)
         }
     }
 

--- a/src/main/kotlin/com/dprint/core/FileUtils.kt
+++ b/src/main/kotlin/com/dprint/core/FileUtils.kt
@@ -5,9 +5,11 @@ import com.google.gson.JsonParser
 import com.google.gson.JsonSyntaxException
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.util.ExecUtil
+import com.intellij.ide.scratch.ScratchUtil
 import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
 import java.io.File
 import java.io.FileReader
 
@@ -77,6 +79,14 @@ object FileUtils {
         LogUtils.info(Bundle.message("notification.config.not.found"), project, LOGGER)
 
         return null
+    }
+
+    fun isScratch(project: Project, virtualFile: VirtualFile): Boolean {
+        val isScratch = ScratchUtil.isScratch(virtualFile)
+        if (isScratch) {
+            LogUtils.info(Bundle.message("formatting.scratch.files", virtualFile.path), project, LOGGER)
+        }
+        return isScratch
     }
 
     private fun checkIsValidJson(project: Project, path: String): Boolean {

--- a/src/main/kotlin/com/dprint/formatter/DprintExternalFormatter.kt
+++ b/src/main/kotlin/com/dprint/formatter/DprintExternalFormatter.kt
@@ -2,13 +2,13 @@ package com.dprint.formatter
 
 import com.dprint.config.ProjectConfiguration
 import com.dprint.core.Bundle
+import com.dprint.core.FileUtils
 import com.dprint.core.LogUtils
 import com.dprint.services.editorservice.EditorServiceManager
 import com.dprint.services.editorservice.FormatResult
 import com.intellij.formatting.service.AsyncDocumentFormattingService
 import com.intellij.formatting.service.AsyncFormattingRequest
 import com.intellij.formatting.service.FormattingService
-import com.intellij.ide.scratch.ScratchUtil
 import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.util.TextRange
@@ -40,7 +40,7 @@ class DprintExternalFormatter : AsyncDocumentFormattingService() {
         // optimisation because they are not part of the project and thus never in config.
         val virtualFile = file.virtualFile ?: file.originalFile.virtualFile
         return virtualFile != null &&
-            ScratchUtil.isScratch(virtualFile) &&
+            !FileUtils.isScratch(file.project, virtualFile) &&
             file.project.service<EditorServiceManager>().canFormatCached(virtualFile.path) != false
     }
 

--- a/src/main/kotlin/com/dprint/listeners/FileOpenedListener.kt
+++ b/src/main/kotlin/com/dprint/listeners/FileOpenedListener.kt
@@ -1,8 +1,8 @@
 package com.dprint.listeners
 
 import com.dprint.config.ProjectConfiguration
+import com.dprint.core.FileUtils
 import com.dprint.services.editorservice.EditorServiceManager
-import com.intellij.ide.scratch.ScratchUtil
 import com.intellij.openapi.components.service
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.fileEditor.FileEditorManagerListener
@@ -19,7 +19,7 @@ class FileOpenedListener : FileEditorManagerListener {
         if (!source.project.service<ProjectConfiguration>().state.enabled) return
 
         // We ignore scratch files as they are never part of config
-        if (ScratchUtil.isScratch(file)) return
+        if (FileUtils.isScratch(source.project, file)) return
 
         val manager = source.project.service<EditorServiceManager>()
         manager.primeCanFormatCacheForFile(file)

--- a/src/main/kotlin/com/dprint/listeners/OnSaveAction.kt
+++ b/src/main/kotlin/com/dprint/listeners/OnSaveAction.kt
@@ -35,7 +35,7 @@ class OnSaveAction : ActionsOnSaveFileDocumentManagerListener.ActionOnSave() {
         for (document in documents) {
             manager.getFile(document)?.let {
                 LogUtils.info(Bundle.message("save.action.run", it.path), project, LOGGER)
-                formatterService.format(it.path, document)
+                formatterService.format(it, document)
             }
         }
     }

--- a/src/main/kotlin/com/dprint/services/FormatterService.kt
+++ b/src/main/kotlin/com/dprint/services/FormatterService.kt
@@ -1,15 +1,15 @@
 package com.dprint.services
 
 import com.dprint.core.Bundle
+import com.dprint.core.FileUtils
 import com.dprint.services.editorservice.EditorServiceManager
 import com.dprint.services.editorservice.FormatResult
-import com.intellij.ide.scratch.ScratchUtil
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.editor.Document
-import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
 
 /**
  * A project service that handles reading virtual files, formatting their contents and writing the formatted result.
@@ -21,10 +21,10 @@ class FormatterService(private val project: Project) {
     /**
      * Attempts to format and save a Document using Dprint.
      */
-    fun format(filePath: String, document: Document) {
+    fun format(virtualFile: VirtualFile, document: Document) {
         val content = document.text
-        val virtualFile = FileDocumentManager.getInstance().getFile(document)
-        if (content.isBlank() || ScratchUtil.isScratch(virtualFile)) return
+        val filePath = virtualFile.path
+        if (content.isBlank() || FileUtils.isScratch(project, virtualFile)) return
 
         if (editorServiceManager.canFormatCached(filePath) == true) {
             val formatHandler: (FormatResult) -> Unit = {

--- a/src/main/kotlin/com/dprint/services/editorservice/EditorServiceManager.kt
+++ b/src/main/kotlin/com/dprint/services/editorservice/EditorServiceManager.kt
@@ -9,7 +9,6 @@ import com.dprint.services.editorservice.v4.EditorServiceV4
 import com.dprint.services.editorservice.v5.EditorServiceV5
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.util.ExecUtil
-import com.intellij.ide.scratch.ScratchUtil
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.logger
@@ -220,7 +219,7 @@ class EditorServiceManager(private val project: Project) {
         maybeInitialiseEditorService()
         clearCanFormatCache()
         for (virtualFile in FileEditorManager.getInstance(project).openFiles) {
-            if (!ScratchUtil.isScratch(virtualFile)) {
+            if (!FileUtils.isScratch(project, virtualFile)) {
                 primeCanFormatCacheForFile(virtualFile)
             }
         }

--- a/src/main/resources/messages/Bundle.properties
+++ b/src/main/resources/messages/Bundle.properties
@@ -54,6 +54,7 @@ formatting.error=Formatting error
 formatting.file=Formatting {0}
 formatting.received.success=Received success bytes.
 formatting.received.value=Received value: {0}
+formatting.scratch.files=Cannot format scratch files, file: {0}
 formatting.sending.success.to.editor.service=Sending success to editor service.
 formatting.sending.to.editor.service=Sending to editor service: {0}.
 notification.config.not.found=Could not detect a config file


### PR DESCRIPTION
## Overview

In my last attempt at this I messed up a single condition leading to some unnecessary dprint restarts but it also wasn't clear to the user why the file wasn't formatted. To make it clear I have created a light wrapper around the `ScratchUtil.isScratch` method that also logs that scratch files cannot be formatted.