### PR TITLE
Exclude diff files from formatting checks

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # -> https://plugins.jetbrains.com/docs/intellij/intellij-artifacts.html
 pluginGroup=com.dprint.intellij.plugin
 pluginName=dprint-intellij-plugin
-pluginVersion=0.4.0.beta.1
+pluginVersion=0.4.0.beta.2
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild=221

--- a/src/main/kotlin/com/dprint/core/FileUtils.kt
+++ b/src/main/kotlin/com/dprint/core/FileUtils.kt
@@ -3,7 +3,6 @@ package com.dprint.core
 import com.dprint.config.ProjectConfiguration
 import com.google.gson.JsonParser
 import com.google.gson.JsonSyntaxException
-import com.intellij.codeInsight.daemon.OutsidersPsiFileSupport
 import com.intellij.diff.util.DiffUtil
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.util.ExecUtil
@@ -94,9 +93,10 @@ object FileUtils {
             LogUtils.info(Bundle.message("formatting.scratch.files", virtualFile.path), project, LOGGER)
         }
 
-        val isOutsiderFile = OutsidersPsiFileSupport.isOutsiderFile(virtualFile)
-        val isDiffFile = DiffUtil.isFileWithoutContent(virtualFile)
-        return !isScratch && !isOutsiderFile && !isDiffFile
+        return virtualFile.isWritable &&
+            virtualFile.isInLocalFileSystem &&
+            !isScratch &&
+            !DiffUtil.isFileWithoutContent(virtualFile)
     }
 
     private fun checkIsValidJson(project: Project, path: String): Boolean {

--- a/src/main/kotlin/com/dprint/formatter/DprintExternalFormatter.kt
+++ b/src/main/kotlin/com/dprint/formatter/DprintExternalFormatter.kt
@@ -44,7 +44,7 @@ class DprintExternalFormatter : AsyncDocumentFormattingService() {
         // optimisation because they are not part of the project and thus never in config.
         val virtualFile = file.virtualFile ?: file.originalFile.virtualFile
         return virtualFile != null &&
-            !FileUtils.isScratch(file.project, virtualFile) &&
+            FileUtils.isFormattableFile(file.project, virtualFile) &&
             file.project.service<EditorServiceManager>().canFormatCached(virtualFile.path) != false
     }
 

--- a/src/main/kotlin/com/dprint/listeners/FileOpenedListener.kt
+++ b/src/main/kotlin/com/dprint/listeners/FileOpenedListener.kt
@@ -19,7 +19,7 @@ class FileOpenedListener : FileEditorManagerListener {
         if (!source.project.service<ProjectConfiguration>().state.enabled) return
 
         // We ignore scratch files as they are never part of config
-        if (FileUtils.isScratch(source.project, file)) return
+        if (!FileUtils.isFormattableFile(source.project, file)) return
 
         val manager = source.project.service<EditorServiceManager>()
         manager.primeCanFormatCacheForFile(file)

--- a/src/main/kotlin/com/dprint/services/FormatterService.kt
+++ b/src/main/kotlin/com/dprint/services/FormatterService.kt
@@ -24,7 +24,7 @@ class FormatterService(private val project: Project) {
     fun format(virtualFile: VirtualFile, document: Document) {
         val content = document.text
         val filePath = virtualFile.path
-        if (content.isBlank() || FileUtils.isScratch(project, virtualFile)) return
+        if (content.isBlank() || !FileUtils.isFormattableFile(project, virtualFile)) return
 
         if (editorServiceManager.canFormatCached(filePath) == true) {
             val formatHandler: (FormatResult) -> Unit = {

--- a/src/main/kotlin/com/dprint/services/editorservice/EditorServiceManager.kt
+++ b/src/main/kotlin/com/dprint/services/editorservice/EditorServiceManager.kt
@@ -219,7 +219,7 @@ class EditorServiceManager(private val project: Project) {
         maybeInitialiseEditorService()
         clearCanFormatCache()
         for (virtualFile in FileEditorManager.getInstance(project).openFiles) {
-            if (!FileUtils.isScratch(project, virtualFile)) {
+            if (FileUtils.isFormattableFile(project, virtualFile)) {
                 primeCanFormatCacheForFile(virtualFile)
             }
         }


### PR DESCRIPTION
## Overview

I have found another file type that can never be formatted, Diff files. These are presented when a user shown a diff view of a file they have staged in IJ.