### PR TITLE
Better v5 error handling.

### DIFF
--- a/src/main/kotlin/com/dprint/services/editorservice/v5/EditorServiceV5.kt
+++ b/src/main/kotlin/com/dprint/services/editorservice/v5/EditorServiceV5.kt
@@ -5,6 +5,7 @@ import com.dprint.core.LogUtils
 import com.dprint.services.editorservice.EditorProcess
 import com.dprint.services.editorservice.EditorService
 import com.dprint.services.editorservice.FormatResult
+import com.dprint.services.editorservice.exceptions.ProcessUnavailableException
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
@@ -56,7 +57,11 @@ class EditorServiceV5(val project: Project) : EditorService {
             runBlocking {
                 withTimeout(SHUTDOWN_TIMEOUT) {
                     launch {
-                        editorProcess.writeBuffer(message.build())
+                        try {
+                            editorProcess.writeBuffer(message.build())
+                        } catch (e: ProcessUnavailableException) {
+                            LOGGER.warn(e)
+                        }
                     }
                 }
             }
@@ -92,7 +97,11 @@ class EditorServiceV5(val project: Project) : EditorService {
 
         pendingMessages.store(message.id, handler)
 
-        editorProcess.writeBuffer(message.build())
+        try {
+            editorProcess.writeBuffer(message.build())
+        } catch (e: ProcessUnavailableException) {
+            LOGGER.warn(e)
+        }
     }
 
     override fun canRangeFormat(): Boolean {
@@ -139,7 +148,11 @@ class EditorServiceV5(val project: Project) : EditorService {
         }
         pendingMessages.store(message.id, handler)
 
-        editorProcess.writeBuffer(message.build())
+        try {
+            editorProcess.writeBuffer(message.build())
+        } catch (e: ProcessUnavailableException) {
+            LOGGER.warn(e)
+        }
 
         LogUtils.info(Bundle.message("editor.service.created.formatting.task", filePath, message.id), project, LOGGER)
 
@@ -158,7 +171,11 @@ class EditorServiceV5(val project: Project) : EditorService {
         val message = createNewMessage(MessageType.CancelFormat)
         LogUtils.info(Bundle.message("editor.service.cancel.format", formatId), project, LOGGER)
         message.addInt(formatId)
-        editorProcess.writeBuffer(message.build())
+        try {
+            editorProcess.writeBuffer(message.build())
+        } catch (e: ProcessUnavailableException) {
+            LOGGER.warn(e)
+        }
         pendingMessages.take(formatId)
     }
 

--- a/src/main/kotlin/com/dprint/services/editorservice/v5/StdoutListener.kt
+++ b/src/main/kotlin/com/dprint/services/editorservice/v5/StdoutListener.kt
@@ -2,6 +2,7 @@ package com.dprint.services.editorservice.v5
 
 import com.dprint.core.Bundle
 import com.dprint.services.editorservice.EditorProcess
+import com.dprint.services.editorservice.exceptions.ProcessUnavailableException
 import com.intellij.openapi.diagnostic.logger
 import java.nio.BufferUnderflowException
 
@@ -35,66 +36,78 @@ class StdoutListener(private val editorProcess: EditorProcess, private val pendi
     }
 
     private fun handleStdout() {
-        val messageId = editorProcess.readInt()
-        val messageType = editorProcess.readInt()
-        val bodyLength = editorProcess.readInt()
-        val body = MessageBody(editorProcess.readBuffer(bodyLength))
-        editorProcess.readAndAssertSuccess()
+        try {
+            val messageId = editorProcess.readInt()
+            val messageType = editorProcess.readInt()
+            val bodyLength = editorProcess.readInt()
+            val body = MessageBody(editorProcess.readBuffer(bodyLength))
+            editorProcess.readAndAssertSuccess()
 
-        when (messageType) {
-            MessageType.SuccessResponse.intValue -> {
-                val responseId = body.readInt()
-                val result = PendingMessages.Result(MessageType.SuccessResponse, null)
-                pendingMessages.take(responseId)?.let { it(result) }
-            }
-            MessageType.ErrorResponse.intValue -> {
-                val responseId = body.readInt()
-                val errorMessage = body.readSizedString()
-                LOGGER.info(Bundle.message("editor.service.received.error.response", errorMessage))
-                val result = PendingMessages.Result(MessageType.ErrorResponse, errorMessage)
-                pendingMessages.take(responseId)?.let { it(result) }
-            }
-            MessageType.Active.intValue -> {
-                sendSuccess(messageId)
-            }
-            MessageType.CanFormatResponse.intValue -> {
-                val responseId = body.readInt()
-                val canFormatResult = body.readInt()
-                val result = PendingMessages.Result(MessageType.CanFormatResponse, canFormatResult == 1)
-                pendingMessages.take(responseId)?.let { it(result) }
-            }
-            MessageType.FormatFileResponse.intValue -> {
-                val responseId = body.readInt()
-                val hasChanged = body.readInt()
-                val text = when (hasChanged == 1) {
-                    true -> body.readSizedString()
-                    false -> null
+            when (messageType) {
+                MessageType.SuccessResponse.intValue -> {
+                    val responseId = body.readInt()
+                    val result = PendingMessages.Result(MessageType.SuccessResponse, null)
+                    pendingMessages.take(responseId)?.let { it(result) }
                 }
-                val result = PendingMessages.Result(MessageType.FormatFileResponse, text)
-                pendingMessages.take(responseId)?.let { it(result) }
+                MessageType.ErrorResponse.intValue -> {
+                    val responseId = body.readInt()
+                    val errorMessage = body.readSizedString()
+                    LOGGER.info(Bundle.message("editor.service.received.error.response", errorMessage))
+                    val result = PendingMessages.Result(MessageType.ErrorResponse, errorMessage)
+                    pendingMessages.take(responseId)?.let { it(result) }
+                }
+                MessageType.Active.intValue -> {
+                    sendSuccess(messageId)
+                }
+                MessageType.CanFormatResponse.intValue -> {
+                    val responseId = body.readInt()
+                    val canFormatResult = body.readInt()
+                    val result = PendingMessages.Result(MessageType.CanFormatResponse, canFormatResult == 1)
+                    pendingMessages.take(responseId)?.let { it(result) }
+                }
+                MessageType.FormatFileResponse.intValue -> {
+                    val responseId = body.readInt()
+                    val hasChanged = body.readInt()
+                    val text = when (hasChanged == 1) {
+                        true -> body.readSizedString()
+                        false -> null
+                    }
+                    val result = PendingMessages.Result(MessageType.FormatFileResponse, text)
+                    pendingMessages.take(responseId)?.let { it(result) }
+                }
+                else -> {
+                    val errorMessage = Bundle.message(
+                        "editor.service.unsupported.message.type",
+                        messageType
+                    )
+                    LOGGER.info(errorMessage)
+                    sendFailure(messageId, errorMessage)
+                }
             }
-            else -> {
-                val errorMessage = Bundle.message(
-                    "editor.service.unsupported.message.type",
-                    messageType
-                )
-                LOGGER.info(errorMessage)
-                sendFailure(messageId, errorMessage)
-            }
+        } catch (e: ProcessUnavailableException) {
+            LOGGER.warn(e)
         }
     }
 
     private fun sendSuccess(messageId: Int) {
         val message = createNewMessage(MessageType.SuccessResponse)
         message.addInt(messageId)
-        sendResponse(message)
+        try {
+            sendResponse(message)
+        } catch (e: ProcessUnavailableException) {
+            LOGGER.warn(e)
+        }
     }
 
     private fun sendFailure(messageId: Int, errorMessage: String) {
         val message = createNewMessage(MessageType.ErrorResponse)
         message.addInt(messageId)
         message.addString(errorMessage)
-        sendResponse(message)
+        try {
+            sendResponse(message)
+        } catch (e: ProcessUnavailableException) {
+            LOGGER.warn(e)
+        }
     }
 
     private fun sendResponse(message: Message) {


### PR DESCRIPTION
## Overview

I noticed that the Tool window can disappear if we have a startup error such as there being no available dprint process. This catches the errors that I believe caused that and logs them as a warning. The user won't see these which I think is fine.