### PR TITLE
Use Gson to parse the config file so that it can handle comments in json.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # -> https://plugins.jetbrains.com/docs/intellij/intellij-artifacts.html
 pluginGroup=com.dprint.intellij.plugin
 pluginName=dprint-intellij-plugin
-pluginVersion=0.4.0.beta.2
+pluginVersion=0.4.0.beta.3
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild=221

--- a/src/main/kotlin/com/dprint/utils/FileUtils.kt
+++ b/src/main/kotlin/com/dprint/utils/FileUtils.kt
@@ -2,6 +2,8 @@ package com.dprint.utils
 
 import com.dprint.config.ProjectConfiguration
 import com.dprint.i18n.DprintBundle
+import com.google.gson.JsonParser
+import com.google.gson.JsonSyntaxException
 import com.intellij.diff.util.DiffUtil
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.util.ExecUtil
@@ -10,8 +12,6 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
-import kotlinx.serialization.SerializationException
-import kotlinx.serialization.json.Json
 import java.io.File
 import java.io.FileReader
 
@@ -97,11 +97,10 @@ fun isFormattableFile(project: Project, virtualFile: VirtualFile): Boolean {
 
 private fun checkIsValidJson(project: Project, path: String): Boolean {
     return try {
-        val reader = FileReader(path)
-        Json.parseToJsonElement(reader.readText())
-        reader.close()
+        // Need to use Gson here to handle json with comments
+        JsonParser.parseReader(FileReader(path))
         true
-    } catch (e: SerializationException) {
+    } catch (e: JsonSyntaxException) {
         errorLogWithConsole(e.message ?: "Failed to parse config JSON", e, project, LOGGER)
         false
     }


### PR DESCRIPTION
## Overview

Title really.

While testing on a larger repo, I found that json config files with comments break kotlin serialization. This moves back to using gson which didn't have the issue before.