### PR TITLE
Fix run on save config and release 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # dprint-intellij-plugin Changelog
 
 ## [Unreleased]
+- Fix issue with run on save config not saving
 
 ## [0.4.1]
 - Fix null pointer issue in external formatter

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # -> https://plugins.jetbrains.com/docs/intellij/intellij-artifacts.html
 pluginGroup=com.dprint.intellij.plugin
 pluginName=dprint-intellij-plugin
-pluginVersion=0.4.1
+pluginVersion=0.4.2
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild=221

--- a/src/main/kotlin/com/dprint/config/ProjectConfigurable.kt
+++ b/src/main/kotlin/com/dprint/config/ProjectConfigurable.kt
@@ -71,8 +71,8 @@ class ProjectConfigurable(private val project: Project) : BoundSearchableConfigu
             row {
                 checkBox(DprintBundle.message("config.verbose.logging"))
                     .bindSelected(
-                        { userConfig.state.runOnSave },
-                        { userConfig.state.runOnSave = it }
+                        { userConfig.state.enableEditorServiceVerboseLogging },
+                        { userConfig.state.enableEditorServiceVerboseLogging = it }
                     )
                     .comment(DprintBundle.message("config.verbose.logging.description"))
             }


### PR DESCRIPTION
Copy paste got me. Effectively, when a user hadn't had any user config already configured IJ wouldn't actually create the file due to this issue with potential clashing config. Users in this instance had run on save checked and verbose not checked, so because it was the same as default config the file was never created.