### PR TITLE
Hotfix: Fix issue for plugins that require commands to be run within the git repository of the project.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # dprint-intellij-plugin Changelog
 
 ## Unreleased
+- Fixed issue for plugins that require the underlying process to be running in the working projects git repository.
 
 ## 0.4.3 - 2023-10-11
 - Update to latest dependencies

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # -> https://plugins.jetbrains.com/docs/intellij/intellij-artifacts.html
 pluginGroup=com.dprint.intellij.plugin
 pluginName=dprint-intellij-plugin
-pluginVersion=0.4.3
+pluginVersion=0.4.4
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild=231


### PR DESCRIPTION
## Overview

An issue was found where plugins could require the underlying dprint commands to be running inside the projects git repository. If they weren't, then a git error was thrown and the dprint schema version could not be determined.

This fixes that by ensuring that the `editor-info` command is run within the director of the dprint configuration file.