### PR TITLE
Set up kotest and mockk plus split formatter service for testing.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,9 @@ repositories {
 dependencies {
     //    implementation(libs.annotations)
     implementation(libs.commonsCollection4)
-    testImplementation(kotlin("test"))
+    testImplementation(libs.kotestAssertions)
+    testImplementation(libs.kotestRunner)
+    testImplementation(libs.mockk)
 }
 
 // Set the JVM language level used to build the project. Use Java 11 for 2020.3+, and Java 17 for 2022.2+.
@@ -85,7 +87,7 @@ fun isNonStable(version: String): Boolean {
 }
 
 tasks {
-    test {
+    withType<Test>().configureEach {
         useJUnitPlatform()
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,14 +3,20 @@ annotations = "24.0.1"
 changelog = "2.2.0"
 commonsCollection4 = "4.4"
 gradleIntelliJPlugin = "1.16.1"
+kotestAssertions = "5.8.0"
+kotestRunner = "5.8.0"
 kotlin = "1.9.22"
 ktlint = "12.0.3"
+mockk = "1.13.8"
 versionCatalogUpdate = "0.8.3"
 versions = "0.50.0"
 
 [libraries]
 annotations = { module = "org.jetbrains:annotations", version.ref = "annotations" }
 commonsCollection4 = { module = "org.apache.commons:commons-collections4", version.ref = "commonsCollection4"}
+kotestAssertions = { module = "io.kotest:kotest-assertions-core", version.ref = "kotestAssertions" }
+kotestRunner = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotestRunner" }
+mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 
 [plugins]
 # Changelog update gradle plugin - https://github.com/JetBrains/gradle-changelog-plugin

--- a/src/main/kotlin/com/dprint/services/FormatterService.kt
+++ b/src/main/kotlin/com/dprint/services/FormatterService.kt
@@ -11,17 +11,34 @@ import com.intellij.openapi.editor.Document
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 
-/**
- * A project service that handles reading virtual files, formatting their contents and writing the formatted result.
- */
-@Service(Service.Level.PROJECT)
-class FormatterService(private val project: Project) {
-    private var editorServiceManager = project.service<EditorServiceManager>()
-
+interface IFormatterService {
     /**
      * Attempts to format and save a Document using Dprint.
      */
     fun format(
+        virtualFile: VirtualFile,
+        document: Document,
+    )
+}
+
+/**
+ * A project service that handles reading virtual files, formatting their contents and writing the formatted result.
+ */
+@Service(Service.Level.PROJECT)
+class FormatterService(private val project: Project) : IFormatterService {
+    private val delegate = FormatterServiceImpl(project, project.service<EditorServiceManager>())
+
+    override fun format(
+        virtualFile: VirtualFile,
+        document: Document,
+    ) {
+        this.delegate.format(virtualFile, document)
+    }
+}
+
+class FormatterServiceImpl(private val project: Project, private val editorServiceManager: EditorServiceManager) :
+    IFormatterService {
+    override fun format(
         virtualFile: VirtualFile,
         document: Document,
     ) {

--- a/src/main/kotlin/com/dprint/services/FormatterService.kt
+++ b/src/main/kotlin/com/dprint/services/FormatterService.kt
@@ -25,8 +25,12 @@ interface IFormatterService {
  * A project service that handles reading virtual files, formatting their contents and writing the formatted result.
  */
 @Service(Service.Level.PROJECT)
-class FormatterService(private val project: Project) : IFormatterService {
-    private val delegate = FormatterServiceImpl(project, project.service<EditorServiceManager>())
+class FormatterService(project: Project) : IFormatterService {
+    private val delegate =
+        FormatterServiceImpl(
+            project,
+            project.service<EditorServiceManager>(),
+        )
 
     override fun format(
         virtualFile: VirtualFile,
@@ -36,7 +40,10 @@ class FormatterService(private val project: Project) : IFormatterService {
     }
 }
 
-class FormatterServiceImpl(private val project: Project, private val editorServiceManager: EditorServiceManager) :
+class FormatterServiceImpl(
+    private val project: Project,
+    private val editorServiceManager: EditorServiceManager,
+) :
     IFormatterService {
     override fun format(
         virtualFile: VirtualFile,

--- a/src/main/kotlin/com/dprint/services/editorservice/EditorServiceManager.kt
+++ b/src/main/kotlin/com/dprint/services/editorservice/EditorServiceManager.kt
@@ -43,7 +43,7 @@ private const val INIT_TIMEOUT = 20L
 
 @Service(Service.Level.PROJECT)
 class EditorServiceManager(private val project: Project) {
-    private var editorService: EditorService? = null
+    private var editorService: IEditorService? = null
     private var configPath: String? = null
     private val taskQueue = BackgroundTaskQueue(project, "Dprint manager task queue")
     private var canFormatCache = LRUMap<String, Boolean>()
@@ -224,7 +224,7 @@ class EditorServiceManager(private val project: Project) {
 
     /**
      * Formats the given file in a background thread and runs the onFinished callback once complete.
-     * See [com.dprint.services.editorservice.EditorService.fmt] for more info on the parameters.
+     * See [com.dprint.services.editorservice.IEditorService.fmt] for more info on the parameters.
      */
     fun format(
         path: String,
@@ -236,7 +236,7 @@ class EditorServiceManager(private val project: Project) {
 
     /**
      * Formats the given file in a background thread and runs the onFinished callback once complete.
-     * See [com.dprint.services.editorservice.EditorService.fmt] for more info on the parameters.
+     * See [com.dprint.services.editorservice.IEditorService.fmt] for more info on the parameters.
      */
     fun format(
         formatId: Int?,

--- a/src/main/kotlin/com/dprint/services/editorservice/IEditorService.kt
+++ b/src/main/kotlin/com/dprint/services/editorservice/IEditorService.kt
@@ -3,7 +3,7 @@ package com.dprint.services.editorservice
 import com.dprint.services.editorservice.exceptions.HandlerNotImplementedException
 import com.intellij.openapi.Disposable
 
-interface EditorService : Disposable {
+interface IEditorService : Disposable {
     /**
      * If enabled, initialises the dprint editor-service so it is ready to format
      */

--- a/src/main/kotlin/com/dprint/services/editorservice/v4/EditorServiceV4.kt
+++ b/src/main/kotlin/com/dprint/services/editorservice/v4/EditorServiceV4.kt
@@ -3,7 +3,7 @@ package com.dprint.services.editorservice.v4
 import com.dprint.config.ProjectConfiguration
 import com.dprint.i18n.DprintBundle
 import com.dprint.services.editorservice.EditorProcess
-import com.dprint.services.editorservice.EditorService
+import com.dprint.services.editorservice.IEditorService
 import com.dprint.services.editorservice.FormatResult
 import com.dprint.utils.infoLogWithConsole
 import com.dprint.utils.warnLogWithConsole
@@ -18,7 +18,7 @@ private const val FORMAT_COMMAND = 2
 private val LOGGER = logger<EditorServiceV4>()
 
 @Service(Service.Level.PROJECT)
-class EditorServiceV4(private val project: Project) : EditorService {
+class EditorServiceV4(private val project: Project) : IEditorService {
     private var editorProcess = EditorProcess(project)
 
     override fun initialiseEditorService() {

--- a/src/main/kotlin/com/dprint/services/editorservice/v4/EditorServiceV4.kt
+++ b/src/main/kotlin/com/dprint/services/editorservice/v4/EditorServiceV4.kt
@@ -3,8 +3,8 @@ package com.dprint.services.editorservice.v4
 import com.dprint.config.ProjectConfiguration
 import com.dprint.i18n.DprintBundle
 import com.dprint.services.editorservice.EditorProcess
-import com.dprint.services.editorservice.IEditorService
 import com.dprint.services.editorservice.FormatResult
+import com.dprint.services.editorservice.IEditorService
 import com.dprint.utils.infoLogWithConsole
 import com.dprint.utils.warnLogWithConsole
 import com.intellij.openapi.components.Service
@@ -45,7 +45,6 @@ class EditorServiceV4(private val project: Project) : IEditorService {
         filePath: String,
         onFinished: (Boolean) -> Unit,
     ) {
-        var status = 0
         infoLogWithConsole(DprintBundle.message("formatting.checking.can.format", filePath), project, LOGGER)
 
         editorProcess.writeInt(CHECK_COMMAND)
@@ -54,7 +53,7 @@ class EditorServiceV4(private val project: Project) : IEditorService {
 
         // https://github.com/dprint/dprint/blob/main/docs/editor-extension-development.md
         // this command sequence returns 1 if the file can be formatted
-        status = editorProcess.readInt()
+        val status: Int = editorProcess.readInt()
         editorProcess.readAndAssertSuccess()
 
         val result = status == 1

--- a/src/main/kotlin/com/dprint/services/editorservice/v5/EditorServiceV5.kt
+++ b/src/main/kotlin/com/dprint/services/editorservice/v5/EditorServiceV5.kt
@@ -2,8 +2,8 @@ package com.dprint.services.editorservice.v5
 
 import com.dprint.i18n.DprintBundle
 import com.dprint.services.editorservice.EditorProcess
-import com.dprint.services.editorservice.IEditorService
 import com.dprint.services.editorservice.FormatResult
+import com.dprint.services.editorservice.IEditorService
 import com.dprint.utils.errorLogWithConsole
 import com.dprint.utils.infoLogWithConsole
 import com.dprint.utils.warnLogWithConsole

--- a/src/main/kotlin/com/dprint/services/editorservice/v5/EditorServiceV5.kt
+++ b/src/main/kotlin/com/dprint/services/editorservice/v5/EditorServiceV5.kt
@@ -2,7 +2,7 @@ package com.dprint.services.editorservice.v5
 
 import com.dprint.i18n.DprintBundle
 import com.dprint.services.editorservice.EditorProcess
-import com.dprint.services.editorservice.EditorService
+import com.dprint.services.editorservice.IEditorService
 import com.dprint.services.editorservice.FormatResult
 import com.dprint.utils.errorLogWithConsole
 import com.dprint.utils.infoLogWithConsole
@@ -20,7 +20,7 @@ private val LOGGER = logger<EditorServiceV5>()
 private const val SHUTDOWN_TIMEOUT = 1000L
 
 @Service(Service.Level.PROJECT)
-class EditorServiceV5(val project: Project) : EditorService {
+class EditorServiceV5(val project: Project) : IEditorService {
     private var editorProcess = EditorProcess(project)
     private var stdoutListener: Thread? = null
     private val pendingMessages = PendingMessages()

--- a/src/test/kotlin/com/dprint/services/FormatterServiceImplTest.kt
+++ b/src/test/kotlin/com/dprint/services/FormatterServiceImplTest.kt
@@ -1,0 +1,63 @@
+package com.dprint.services
+
+import com.dprint.services.editorservice.EditorServiceManager
+import com.dprint.utils.isFormattableFile
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import io.kotest.core.spec.style.FunSpec
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.verify
+
+class FormatterServiceImplTest : FunSpec({
+    val testPath = "/test/path"
+    val testText = "val test = \"test\""
+
+    mockkStatic(::isFormattableFile)
+
+    val virtualFile = mockk<VirtualFile>()
+    val document = mockk<Document>()
+    val project = mockk<Project>()
+    val editorServiceManager = mockk<EditorServiceManager>(relaxed = true)
+
+    val formatterService = FormatterServiceImpl(project, editorServiceManager)
+
+    beforeEach {
+        every { virtualFile.path } returns testPath
+        every { document.text } returns testText
+    }
+
+    afterEach {
+        clearAllMocks()
+    }
+
+    test("It doesn't format if cached can format result is false") {
+        every { isFormattableFile(project, virtualFile) } returns true
+        every { editorServiceManager.canFormatCached(testPath) } returns false
+
+        formatterService.format(virtualFile, document)
+
+        verify(exactly = 0) { editorServiceManager.format(testPath, testPath, any()) }
+    }
+
+    test("It doesn't format if cached can format result is null") {
+        every { isFormattableFile(project, virtualFile) } returns true
+        every { editorServiceManager.canFormatCached(testPath) } returns null
+
+        formatterService.format(virtualFile, document)
+
+        verify(exactly = 0) { editorServiceManager.format(testPath, testPath, any()) }
+    }
+
+    test("It formats if cached can format result is true") {
+        every { isFormattableFile(project, virtualFile) } returns true
+        every { editorServiceManager.canFormatCached(testPath) } returns true
+
+        formatterService.format(virtualFile, document)
+
+        verify(exactly = 1) { editorServiceManager.format(testPath, testText, any()) }
+    }
+})

--- a/src/test/kotlin/com/dprint/services/editorservice/v5/MessageBodyTest.kt
+++ b/src/test/kotlin/com/dprint/services/editorservice/v5/MessageBodyTest.kt
@@ -1,21 +1,19 @@
 package com.dprint.services.editorservice.v5
 
-import org.junit.jupiter.api.Test
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 import java.nio.ByteBuffer
-import kotlin.test.assertEquals
 
-internal class MessageBodyTest {
-    @Test
-    fun testItDecodesAnInt() {
+class MessageBodyTest : FunSpec({
+    test("It decodes an int") {
         val int = 7
         val buffer = ByteBuffer.allocate(4)
         buffer.putInt(7)
         val messageBody = MessageBody(buffer.array())
-        assertEquals(int, messageBody.readInt())
+        messageBody.readInt() shouldBe int
     }
 
-    @Test
-    fun testItDecodesAString() {
+    test("It decodes a string") {
         val text = "blah!"
         val textAsByteArray = text.encodeToByteArray()
         val sizeBuffer = ByteBuffer.allocate(4)
@@ -25,6 +23,6 @@ internal class MessageBodyTest {
         buffer.put(sizeBuffer.array())
         buffer.put(textAsByteArray)
         val messageBody = MessageBody(buffer.array())
-        assertEquals(text, messageBody.readSizedString())
+        messageBody.readSizedString() shouldBe text
     }
-}
+})

--- a/src/test/kotlin/com/dprint/services/editorservice/v5/MessageTest.kt
+++ b/src/test/kotlin/com/dprint/services/editorservice/v5/MessageTest.kt
@@ -1,13 +1,13 @@
 package com.dprint.services.editorservice.v5
 
 import com.intellij.util.io.toByteArray
-import org.junit.jupiter.api.Test
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 import java.nio.ByteBuffer
-import kotlin.test.assertContentEquals
 
-internal class MessageTest {
-    @Test
-    fun testItBuildsAStringMessage() {
+internal class MessageTest : FunSpec({
+
+    test("It builds a string message") {
         val id = 1
         val type = MessageType.Active
         val text = "blah!"
@@ -27,11 +27,10 @@ internal class MessageTest {
         expected.put(textAsBytes)
         expected.put(SUCCESS_MESSAGE)
 
-        assertContentEquals(expected.array(), message.build())
+        message.build() shouldBe expected.array()
     }
 
-    @Test
-    fun testItBuildsAnIntMessage() {
+    test("It builds an int message") {
         val id = 1
         val type = MessageType.Active
         val int = 2
@@ -47,11 +46,10 @@ internal class MessageTest {
         expected.put(createIntBytes(int))
         expected.put(SUCCESS_MESSAGE)
 
-        assertContentEquals(expected.array(), message.build())
+        message.build() shouldBe expected.array()
     }
 
-    @Test
-    fun testItBuildsACombinedMessage() {
+    test("It builds a combined message") {
         val id = 1
         val type = MessageType.Active
         val int = 2
@@ -74,12 +72,12 @@ internal class MessageTest {
         expected.put(textAsBytes)
         expected.put(SUCCESS_MESSAGE)
 
-        assertContentEquals(expected.array(), message.build())
+        message.build() shouldBe expected.array()
     }
+})
 
-    private fun createIntBytes(int: Int): ByteArray {
-        val buffer = ByteBuffer.allocate(4)
-        buffer.putInt(int)
-        return buffer.toByteArray()
-    }
+private fun createIntBytes(int: Int): ByteArray {
+    val buffer = ByteBuffer.allocate(4)
+    buffer.putInt(int)
+    return buffer.toByteArray()
 }


### PR DESCRIPTION
## Overview 

This adds kotest and mockk test dependencies, swaps existing tests over to them, and creates tests for the formatter service.