### PR TITLE
Split external formatter

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,10 +36,9 @@ dependencies {
 
 // Set the JVM language level used to build the project. Use Java 11 for 2020.3+, and Java 17 for 2022.2+.
 kotlin {
-    @Suppress("UnstableApiUsage")
     jvmToolchain {
         languageVersion = JavaLanguageVersion.of(17)
-        vendor = JvmVendorSpec.JETBRAINS
+        vendor = JvmVendorSpec.AZUL
     }
 }
 

--- a/src/main/kotlin/com/dprint/formatter/DprintExternalFormatter.kt
+++ b/src/main/kotlin/com/dprint/formatter/DprintExternalFormatter.kt
@@ -4,13 +4,9 @@ import com.dprint.config.ProjectConfiguration
 import com.dprint.config.UserConfiguration
 import com.dprint.i18n.DprintBundle
 import com.dprint.services.editorservice.EditorServiceManager
-import com.dprint.services.editorservice.FormatResult
-import com.dprint.services.editorservice.exceptions.ProcessUnavailableException
-import com.dprint.utils.errorLogWithConsole
 import com.dprint.utils.infoConsole
 import com.dprint.utils.infoLogWithConsole
 import com.dprint.utils.isFormattableFile
-import com.dprint.utils.warnLogWithConsole
 import com.intellij.formatting.service.AsyncDocumentFormattingService
 import com.intellij.formatting.service.AsyncFormattingRequest
 import com.intellij.formatting.service.FormattingService
@@ -18,18 +14,12 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiFile
-import java.util.concurrent.CancellationException
-import java.util.concurrent.CompletableFuture
-import java.util.concurrent.ExecutionException
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.TimeoutException
 
 private val LOGGER = logger<DprintExternalFormatter>()
 private const val NAME = "dprintfmt"
-private const val FORMATTING_TIMEOUT = 10L
 
 /**
- * Thia class is the recommended way to implement an external formatter in the IJ
+ * This class is the recommended way to implement an external formatter in the IJ
  * framework.
  *
  * How it works is that extends AsyncDocumentFormattingService and IJ
@@ -102,135 +92,18 @@ class DprintExternalFormatter : AsyncDocumentFormattingService() {
         infoLogWithConsole(DprintBundle.message("external.formatter.creating.task", path), project, LOGGER)
 
         return object : FormattingTask {
-            private var formattingId: Int? = editorServiceManager.maybeGetFormatId()
-            private var isCancelled = false
-            private val baseFormatFuture = CompletableFuture<FormatResult>()
-            private var activeFormatFuture: CompletableFuture<FormatResult>? = null
+            val dprintTask = DprintFormattingTask(project, editorServiceManager, formattingRequest)
 
             override fun run() {
-                val content = formattingRequest.documentText
-                val ranges = formattingRequest.formattingRanges
-
-                infoLogWithConsole(
-                    DprintBundle.message("external.formatter.running.task", formattingId ?: path),
-                    project,
-                    LOGGER,
-                )
-
-                for (range in ranges.subList(1, ranges.size)) {
-                    baseFormatFuture.thenApply {
-                        if (isCancelled) {
-                            it
-                        } else {
-                            val resultContent = it.formattedContent
-                            val nextFuture = CompletableFuture<FormatResult>()
-                            activeFormatFuture = nextFuture
-                            val nextHandler: (FormatResult) -> Unit = { nextResult ->
-                                nextFuture.complete(nextResult)
-                            }
-                            if (resultContent != null) {
-                                // Need to update the formatting id so the correct job would be cancelled
-                                formattingId = editorServiceManager.maybeGetFormatId()
-                                editorServiceManager.format(
-                                    formattingId,
-                                    path,
-                                    resultContent,
-                                    range.startOffset,
-                                    getEndOfRange(content, range),
-                                    nextHandler,
-                                )
-                            }
-
-                            getFuture(nextFuture)
-                        }
-                    }
-                }
-
-                // If the version can't range format we always return null, in this case the underlying process will
-                // extract the start byte position (0) and end byte position (content.encodeToByteArray().size) for the
-                // whole file
-                val initialRange =
-                    if (editorServiceManager.canRangeFormat() && ranges.size > 0) ranges.first() else null
-                val initialHandler: (FormatResult) -> Unit = {
-                    baseFormatFuture.complete(it)
-                }
-
-                editorServiceManager.format(
-                    formattingId,
-                    path,
-                    content,
-                    initialRange?.startOffset,
-                    getEndOfRange(content, initialRange),
-                    initialHandler,
-                )
-                // Timeouts are handled at the EditorServiceManager level and an empty result will be
-                // returned if something goes wrong
-                val result = getFuture(baseFormatFuture)
-
-                if (isCancelled || result == null) return
-
-                val error = result.error
-                if (error != null) {
-                    formattingRequest.onError(DprintBundle.message("formatting.error"), error)
-                } else {
-                    // If the result is a no op it will be null, in which case we pass the original content back in
-                    formattingRequest.onTextReady(result.formattedContent ?: content)
-                }
-            }
-
-            private fun getFuture(future: CompletableFuture<FormatResult>): FormatResult? {
-                return try {
-                    future.get(FORMATTING_TIMEOUT, TimeUnit.SECONDS)
-                } catch (e: CancellationException) {
-                    errorLogWithConsole("External format process cancelled", e, project, LOGGER)
-                    null
-                } catch (e: TimeoutException) {
-                    errorLogWithConsole("External format process timed out", e, project, LOGGER)
-                    formattingRequest.onError("Dprint external formatter", "Format process timed out")
-                    editorServiceManager.restartEditorService()
-                    null
-                } catch (e: ExecutionException) {
-                    if (e.cause is ProcessUnavailableException) {
-                        warnLogWithConsole(
-                            DprintBundle.message("editor.service.process.is.dead"),
-                            e.cause,
-                            project,
-                            LOGGER,
-                        )
-                    }
-                    errorLogWithConsole("External format process failed", e, project, LOGGER)
-                    formattingRequest.onError("Dprint external formatter", "Format process failed")
-                    editorServiceManager.restartEditorService()
-                    null
-                } catch (e: InterruptedException) {
-                    errorLogWithConsole("External format process interrupted", e, project, LOGGER)
-                    formattingRequest.onError("Dprint external formatter", "Format process interrupted")
-                    editorServiceManager.restartEditorService()
-                    null
-                }
+                return dprintTask.run(path)
             }
 
             override fun cancel(): Boolean {
-                if (!editorServiceManager.canCancelFormat()) return false
-
-                val formatId = formattingId
-                isCancelled = true
-                if (formatId != null) {
-                    infoLogWithConsole(
-                        DprintBundle.message("external.formatter.cancelling.task", formattingId ?: path),
-                        project,
-                        LOGGER,
-                    )
-                    editorServiceManager.cancelFormat(formatId)
-                }
-                // Clean up state so process can complete
-                baseFormatFuture.cancel(true)
-                activeFormatFuture?.cancel(true)
-                return true
+                return dprintTask.cancel()
             }
 
             override fun isRunUnderProgress(): Boolean {
-                return true
+                return dprintTask.isRunUnderProgress()
             }
         }
     }

--- a/src/main/kotlin/com/dprint/formatter/DprintExternalFormatter.kt
+++ b/src/main/kotlin/com/dprint/formatter/DprintExternalFormatter.kt
@@ -95,10 +95,10 @@ class DprintExternalFormatter : AsyncDocumentFormattingService() {
         infoLogWithConsole(DprintBundle.message("external.formatter.creating.task", path), project, LOGGER)
 
         return object : FormattingTask {
-            val dprintTask = DprintFormattingTask(project, editorServiceManager, formattingRequest)
+            val dprintTask = DprintFormattingTask(project, editorServiceManager, formattingRequest, path)
 
             override fun run() {
-                return dprintTask.run(path)
+                return dprintTask.run()
             }
 
             override fun cancel(): Boolean {

--- a/src/main/kotlin/com/dprint/formatter/DprintFormattingTask.kt
+++ b/src/main/kotlin/com/dprint/formatter/DprintFormattingTask.kt
@@ -59,19 +59,19 @@ class DprintFormattingTask(
         var nextFuture = baseFormatFuture
         for (range in ranges.subList(0, ranges.size)) {
             nextFuture.thenCompose { formatResult ->
-                if (isCancelled) {
-                    // Revert to the initial contents
-                    CompletableFuture.completedFuture(initialResult)
-                } else {
-                    nextFuture =
+                nextFuture =
+                    if (isCancelled) {
+                        // Revert to the initial contents
+                        CompletableFuture.completedFuture(initialResult)
+                    } else {
                         applyNextRangeFormat(
                             path,
                             formatResult,
                             getStartOfRange(formatResult.formattedContent, content, range),
                             getEndOfRange(formatResult.formattedContent, content, range),
                         )
-                    nextFuture
-                }
+                    }
+                nextFuture
             }
         }
 

--- a/src/main/kotlin/com/dprint/formatter/DprintFormattingTask.kt
+++ b/src/main/kotlin/com/dprint/formatter/DprintFormattingTask.kt
@@ -1,0 +1,169 @@
+package com.dprint.formatter
+
+import com.dprint.i18n.DprintBundle
+import com.dprint.services.editorservice.EditorServiceManager
+import com.dprint.services.editorservice.FormatResult
+import com.dprint.services.editorservice.exceptions.ProcessUnavailableException
+import com.dprint.utils.errorLogWithConsole
+import com.dprint.utils.infoLogWithConsole
+import com.dprint.utils.warnLogWithConsole
+import com.intellij.formatting.service.AsyncFormattingRequest
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.TextRange
+import java.util.concurrent.CancellationException
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+
+private val LOGGER = logger<DprintFormattingTask>()
+private const val FORMATTING_TIMEOUT = 10L
+
+class DprintFormattingTask(
+    private val project: Project,
+    private val editorServiceManager: EditorServiceManager,
+    private val formattingRequest: AsyncFormattingRequest,
+) {
+    private var formattingId: Int? = editorServiceManager.maybeGetFormatId()
+    private var isCancelled = false
+    private val baseFormatFuture = CompletableFuture<FormatResult>()
+    private var activeFormatFuture: CompletableFuture<FormatResult>? = null
+
+    fun run(path: String) {
+        val content = formattingRequest.documentText
+        val ranges = formattingRequest.formattingRanges
+
+        infoLogWithConsole(
+            DprintBundle.message("external.formatter.running.task", formattingId ?: path),
+            project,
+            LOGGER,
+        )
+
+        for (range in ranges.subList(1, ranges.size)) {
+            baseFormatFuture.thenApply {
+                if (isCancelled) {
+                    it
+                } else {
+                    val resultContent = it.formattedContent
+                    val nextFuture = CompletableFuture<FormatResult>()
+                    activeFormatFuture = nextFuture
+                    val nextHandler: (FormatResult) -> Unit = { nextResult ->
+                        nextFuture.complete(nextResult)
+                    }
+                    if (resultContent != null) {
+                        // Need to update the formatting id so the correct job would be cancelled
+                        formattingId = editorServiceManager.maybeGetFormatId()
+                        editorServiceManager.format(
+                            formattingId,
+                            path,
+                            resultContent,
+                            range.startOffset,
+                            getEndOfRange(content, range),
+                            nextHandler,
+                        )
+                    }
+
+                    getFuture(nextFuture)
+                }
+            }
+        }
+
+        // If the version can't range format we always return null, in this case the underlying process will
+        // extract the start byte position (0) and end byte position (content.encodeToByteArray().size) for the
+        // whole file
+        val initialRange =
+            if (editorServiceManager.canRangeFormat() && ranges.size > 0) ranges.first() else null
+        val initialHandler: (FormatResult) -> Unit = {
+            baseFormatFuture.complete(it)
+        }
+
+        editorServiceManager.format(
+            formattingId,
+            path,
+            content,
+            initialRange?.startOffset,
+            getEndOfRange(content, initialRange),
+            initialHandler,
+        )
+        // Timeouts are handled at the EditorServiceManager level and an empty result will be
+        // returned if something goes wrong
+        val result = getFuture(baseFormatFuture)
+
+        if (isCancelled || result == null) return
+
+        val error = result.error
+        if (error != null) {
+            formattingRequest.onError(DprintBundle.message("formatting.error"), error)
+        } else {
+            // If the result is a no op it will be null, in which case we pass the original content back in
+            formattingRequest.onTextReady(result.formattedContent ?: content)
+        }
+    }
+
+    private fun getFuture(future: CompletableFuture<FormatResult>): FormatResult? {
+        return try {
+            future.get(FORMATTING_TIMEOUT, TimeUnit.SECONDS)
+        } catch (e: CancellationException) {
+            errorLogWithConsole("External format process cancelled", e, project, LOGGER)
+            null
+        } catch (e: TimeoutException) {
+            errorLogWithConsole("External format process timed out", e, project, LOGGER)
+            formattingRequest.onError("Dprint external formatter", "Format process timed out")
+            editorServiceManager.restartEditorService()
+            null
+        } catch (e: ExecutionException) {
+            if (e.cause is ProcessUnavailableException) {
+                warnLogWithConsole(
+                    DprintBundle.message("editor.service.process.is.dead"),
+                    e.cause,
+                    project,
+                    LOGGER,
+                )
+            }
+            errorLogWithConsole("External format process failed", e, project, LOGGER)
+            formattingRequest.onError("Dprint external formatter", "Format process failed")
+            editorServiceManager.restartEditorService()
+            null
+        } catch (e: InterruptedException) {
+            errorLogWithConsole("External format process interrupted", e, project, LOGGER)
+            formattingRequest.onError("Dprint external formatter", "Format process interrupted")
+            editorServiceManager.restartEditorService()
+            null
+        }
+    }
+
+    fun cancel(): Boolean {
+        if (!editorServiceManager.canCancelFormat()) return false
+
+        val formatId = formattingId
+        isCancelled = true
+        formatId?.let {
+            infoLogWithConsole(
+                DprintBundle.message("external.formatter.cancelling.task", it),
+                project,
+                LOGGER,
+            )
+            editorServiceManager.cancelFormat(it)
+        }
+        // Clean up state so process can complete
+        baseFormatFuture.cancel(true)
+        activeFormatFuture?.cancel(true)
+        return true
+    }
+
+    fun isRunUnderProgress(): Boolean {
+        return true
+    }
+}
+
+private fun getEndOfRange(
+    content: String,
+    range: TextRange?,
+): Int? {
+    return when {
+        range == null -> null
+        range.endOffset > content.length -> content.length
+        else -> range.endOffset
+    }
+}

--- a/src/main/kotlin/com/dprint/formatter/DprintFormattingTask.kt
+++ b/src/main/kotlin/com/dprint/formatter/DprintFormattingTask.kt
@@ -201,7 +201,11 @@ private fun getStartOfRange(
     // that ranges do not overlap, so we can use the diff to the original content length to know where the
     // new range will shift after each range format.
     val rangeOffset = currentContent.length - originalContent.length
-    return range.startOffset + rangeOffset
+    val startOffset = range.startOffset + rangeOffset
+    return when {
+        startOffset > currentContent.length -> currentContent.length
+        else -> startOffset
+    }
 }
 
 private fun getEndOfRange(
@@ -218,7 +222,7 @@ private fun getEndOfRange(
     val rangeOffset = currentContent.length - originalContent.length
     val endOffset = range.endOffset + rangeOffset
     return when {
-        rangeOffset > currentContent.length -> currentContent.length
+        endOffset < 0 -> 0
         else -> endOffset
     }
 }

--- a/src/main/resources/messages/Bundle.properties
+++ b/src/main/resources/messages/Bundle.properties
@@ -69,6 +69,10 @@ external.formatter.cannot.format=Dprint cannot format {0}, IntelliJ formatter wi
 external.formatter.creating.task=Creating IntelliJ CodeStyle Formatting Task for {0}.
 external.formatter.not.configured.to.override=Dprint is not configured to override the IntelliJ formatter.
 external.formatter.range.formatting=Range formatting is not currently implemented, maybe soon.
+external.formatter.range.overlapping=Formatting ranges overlap and dprint cannot format these. Consider formatting the \
+  whole file.
+external.formatter.illegal.state=Range format attempted without content, start or end index. Start={0}, End={1}, \
+  Content={2}
 external.formatter.running.task=Running CodeStyle formatting task {0}
 formatting.can.format={0} can be formatted
 formatting.cannot.determine.file.path=Cannot determine file path to format.

--- a/src/test/kotlin/com/dprint/formatter/DprintFormattingTaskTest.kt
+++ b/src/test/kotlin/com/dprint/formatter/DprintFormattingTaskTest.kt
@@ -1,0 +1,134 @@
+package com.dprint.formatter
+
+import com.dprint.services.editorservice.EditorServiceManager
+import com.dprint.services.editorservice.FormatResult
+import com.dprint.utils.infoLogWithConsole
+import com.intellij.formatting.service.AsyncFormattingRequest
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.TextRange
+import io.kotest.core.spec.style.FunSpec
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.verify
+
+class DprintFormattingTaskTest : FunSpec({
+    val path = "/some/path"
+
+    mockkStatic(::infoLogWithConsole)
+
+    val project = mockk<Project>()
+    val editorServiceManager = mockk<EditorServiceManager>()
+    val formattingRequest = mockk<AsyncFormattingRequest>(relaxed = true)
+    lateinit var dprintFormattingTask: DprintFormattingTask
+
+    beforeEach {
+        every { infoLogWithConsole(any(), project, any()) } returns Unit
+        every { editorServiceManager.maybeGetFormatId() } returns 1
+
+        dprintFormattingTask = DprintFormattingTask(project, editorServiceManager, formattingRequest, path)
+    }
+
+    afterEach { clearAllMocks() }
+
+    test("it calls editorServiceManager.format correctly when range formatting is disabled") {
+        val testContent = "val test =   \"test\""
+        val successContent = "val test = \"test\""
+        val formatResult = FormatResult()
+        val onFinished = slot<(FormatResult) -> Unit>()
+
+        every { formattingRequest.documentText } returns testContent
+        every { formattingRequest.formattingRanges } returns mutableListOf(TextRange(0, testContent.length))
+        every { editorServiceManager.canRangeFormat() } returns false
+        // range indexes should be null as range format is disabled
+        every {
+            editorServiceManager.format(
+                any(), path, testContent, 0, testContent.length, capture(onFinished),
+            )
+        } answers {
+            formatResult.formattedContent = successContent
+            onFinished.captured.invoke(formatResult)
+        }
+
+        dprintFormattingTask.run()
+
+        verify(exactly = 1) { editorServiceManager.format(any(), path, testContent, 0, testContent.length, any()) }
+        verify { formattingRequest.onTextReady(successContent) }
+    }
+
+    test("it calls editorServiceManager.format correctly when range formatting has a single range") {
+        val testContent = "val test =   \"test\""
+        val successContent = "val test = \"test\""
+        val formatResult = FormatResult()
+        val onFinished = slot<(FormatResult) -> Unit>()
+
+        every { formattingRequest.documentText } returns testContent
+        every { formattingRequest.formattingRanges } returns mutableListOf(TextRange(0, testContent.length))
+        every { editorServiceManager.canRangeFormat() } returns true
+        // range indexes should be null as range format is disabled
+        every {
+            editorServiceManager.format(
+                any(), path, testContent, 0, testContent.length, capture(onFinished),
+            )
+        } answers {
+            formatResult.formattedContent = successContent
+            onFinished.captured.invoke(formatResult)
+        }
+
+        dprintFormattingTask.run()
+
+        verify(exactly = 1) { editorServiceManager.format(any(), path, testContent, 0, testContent.length, any()) }
+        verify { formattingRequest.onTextReady(successContent) }
+    }
+
+    test("it calls editorServiceManager.format correctly when range formatting has multiple ranges") {
+        val testContentPart1 = "val    test"
+        val testContentPart2 = " =   \"test\""
+        val testContent = testContentPart1 + testContentPart2
+
+        val successContentPart1 = "val test =   \"test\""
+        val successContentPart2 = "val test = \"test\""
+
+        val formatResult1 = FormatResult()
+        formatResult1.formattedContent = successContentPart1
+        val onFinished1 = slot<(FormatResult) -> Unit>()
+
+        val formatResult2 = FormatResult()
+        val onFinished2 = slot<(FormatResult) -> Unit>()
+
+        every { formattingRequest.documentText } returns testContent
+        every {
+            formattingRequest.formattingRanges
+        } returns
+            mutableListOf(
+                TextRange(0, testContentPart1.length),
+                TextRange(testContentPart1.length, testContent.length),
+            )
+        every { editorServiceManager.canRangeFormat() } returns true
+        // range indexes should be null as range format is disabled
+        every {
+            editorServiceManager.format(
+                1, path, testContent, any(), any(), capture(onFinished1),
+            )
+        } answers {
+            onFinished1.captured.invoke(formatResult1)
+        }
+
+        every {
+            editorServiceManager.format(
+                1, path, successContentPart1, any(), any(), capture(onFinished2),
+            )
+        } answers {
+            formatResult2.formattedContent = successContentPart2
+            onFinished2.captured.invoke(formatResult2)
+        }
+
+        dprintFormattingTask.run()
+
+        verify(exactly = 1) { editorServiceManager.format(1, path, testContent, 0, testContentPart1.length, any()) }
+        verify(exactly = 1) { editorServiceManager.format(1, path, successContentPart1, 8, successContentPart1.length, any()) }
+        verify { formattingRequest.onTextReady(successContentPart2) }
+    }
+})

--- a/src/test/kotlin/com/dprint/formatter/DprintFormattingTaskTest.kt
+++ b/src/test/kotlin/com/dprint/formatter/DprintFormattingTaskTest.kt
@@ -14,6 +14,7 @@ import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.slot
 import io.mockk.verify
+import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
 
 class DprintFormattingTaskTest : FunSpec({
@@ -167,6 +168,7 @@ class DprintFormattingTaskTest : FunSpec({
         dprintFormattingTask.run()
 
         verify(exactly = 1) { editorServiceManager.format(any(), path, testContent, 0, testContent.length, any()) }
+        verify(exactly = 1) { errorLogWithConsole(any(), any(CancellationException::class), project, any()) }
         verify(exactly = 0) { formattingRequest.onTextReady(any()) }
     }
 })

--- a/src/test/kotlin/com/dprint/formatter/DprintFormattingTaskTest.kt
+++ b/src/test/kotlin/com/dprint/formatter/DprintFormattingTaskTest.kt
@@ -128,7 +128,9 @@ class DprintFormattingTaskTest : FunSpec({
         dprintFormattingTask.run()
 
         verify(exactly = 1) { editorServiceManager.format(1, path, testContent, 0, testContentPart1.length, any()) }
-        verify(exactly = 1) { editorServiceManager.format(1, path, successContentPart1, 8, successContentPart1.length, any()) }
+        verify(
+            exactly = 1,
+        ) { editorServiceManager.format(1, path, successContentPart1, 8, successContentPart1.length, any()) }
         verify { formattingRequest.onTextReady(successContentPart2) }
     }
 })

--- a/src/test/kotlin/com/dprint/formatter/DprintFormattingTaskTest.kt
+++ b/src/test/kotlin/com/dprint/formatter/DprintFormattingTaskTest.kt
@@ -136,7 +136,16 @@ class DprintFormattingTaskTest : FunSpec({
         verify(exactly = 1) { editorServiceManager.format(1, path, testContent, 0, unformattedPart1.length, any()) }
         verify(
             exactly = 1,
-        ) { editorServiceManager.format(2, path, successContentPart1, formattedPart1.length, formattedPart1.length + unformattedPart2.length, any()) }
+        ) {
+            editorServiceManager.format(
+                2,
+                path,
+                successContentPart1,
+                formattedPart1.length,
+                formattedPart1.length + unformattedPart2.length,
+                any(),
+            )
+        }
         verify { formattingRequest.onTextReady(successContentPart2) }
     }
 


### PR DESCRIPTION
## Overview

This splits up the external formatter class as it is too large and also hard to test with how the IJ class extension works.

I have created a `DprintFormattingTask` which mirrors the methods from the `AsyncFormattingTask`. Unfortunately, I cannot extend it directly as it is package private to the `AsyncDocumentFormattingService`.

Also added tests and fixed up the range and cancel implementations to work should they ever be enabled.