### PR TITLE
Convert FormatResult into a data class

### DIFF
--- a/src/main/kotlin/com/dprint/formatter/DprintFormattingTask.kt
+++ b/src/main/kotlin/com/dprint/formatter/DprintFormattingTask.kt
@@ -51,8 +51,7 @@ class DprintFormattingTask(
             LOGGER,
         )
 
-        val initialResult = FormatResult()
-        initialResult.formattedContent = content
+        val initialResult = FormatResult(formattedContent = content)
         val baseFormatFuture = CompletableFuture.completedFuture(initialResult)
         allFormatFutures.add(baseFormatFuture)
 

--- a/src/main/kotlin/com/dprint/services/editorservice/FormatResult.kt
+++ b/src/main/kotlin/com/dprint/services/editorservice/FormatResult.kt
@@ -2,5 +2,7 @@ package com.dprint.services.editorservice
 
 /**
  * The resulting state of running the Dprint formatter.
+ *
+ * If both parameters are null, it represents a no-op from the format operation.
  */
 data class FormatResult(val formattedContent: String? = null, val error: String? = null)

--- a/src/main/kotlin/com/dprint/services/editorservice/FormatResult.kt
+++ b/src/main/kotlin/com/dprint/services/editorservice/FormatResult.kt
@@ -3,14 +3,4 @@ package com.dprint.services.editorservice
 /**
  * The resulting state of running the Dprint formatter.
  */
-class FormatResult {
-    /**
-     * The results of the formatting if successful.
-     */
-    var formattedContent: String? = null
-
-    /**
-     * The error message if formatting was not successful. This can come from custom messages, stderr or stdin.
-     */
-    var error: String? = null
-}
+data class FormatResult(val formattedContent: String? = null, val error: String? = null)

--- a/src/main/kotlin/com/dprint/services/editorservice/v4/EditorServiceV4.kt
+++ b/src/main/kotlin/com/dprint/services/editorservice/v4/EditorServiceV4.kt
@@ -73,7 +73,7 @@ class EditorServiceV4(private val project: Project) : IEditorService {
         content: String,
         onFinished: (FormatResult) -> Unit,
     ): Int? {
-        val result = FormatResult()
+        var result = FormatResult()
 
         infoLogWithConsole(DprintBundle.message("formatting.file", filePath), project, LOGGER)
         editorProcess.writeInt(FORMAT_COMMAND)
@@ -90,7 +90,7 @@ class EditorServiceV4(private val project: Project) : IEditorService {
                 )
             } // no-op as content didn't change
             1 -> {
-                result.formattedContent = editorProcess.readString()
+                result = FormatResult(formattedContent = editorProcess.readString())
                 infoLogWithConsole(
                     DprintBundle.message("editor.service.format.succeeded", filePath),
                     project,
@@ -100,7 +100,7 @@ class EditorServiceV4(private val project: Project) : IEditorService {
 
             2 -> {
                 val error = editorProcess.readString()
-                result.error = error
+                result = FormatResult(error = error)
                 warnLogWithConsole(
                     DprintBundle.message("editor.service.format.failed", filePath, error),
                     project,

--- a/src/test/kotlin/com/dprint/formatter/DprintFormattingTaskTest.kt
+++ b/src/test/kotlin/com/dprint/formatter/DprintFormattingTaskTest.kt
@@ -39,7 +39,7 @@ class DprintFormattingTaskTest : FunSpec({
     test("it calls editorServiceManager.format correctly when range formatting is disabled") {
         val testContent = "val test =   \"test\""
         val successContent = "val test = \"test\""
-        val formatResult = FormatResult()
+        val formatResult = FormatResult(formattedContent = successContent)
         val onFinished = slot<(FormatResult) -> Unit>()
 
         every { formattingRequest.documentText } returns testContent
@@ -51,7 +51,6 @@ class DprintFormattingTaskTest : FunSpec({
                 1, path, testContent, 0, testContent.length, capture(onFinished),
             )
         } answers {
-            formatResult.formattedContent = successContent
             onFinished.captured.invoke(formatResult)
         }
 
@@ -64,7 +63,7 @@ class DprintFormattingTaskTest : FunSpec({
     test("it calls editorServiceManager.format correctly when range formatting has a single range") {
         val testContent = "val test =   \"test\""
         val successContent = "val test = \"test\""
-        val formatResult = FormatResult()
+        val formatResult = FormatResult(formattedContent = successContent)
         val onFinished = slot<(FormatResult) -> Unit>()
 
         every { formattingRequest.documentText } returns testContent
@@ -76,7 +75,6 @@ class DprintFormattingTaskTest : FunSpec({
                 1, path, testContent, 0, testContent.length - 1, capture(onFinished),
             )
         } answers {
-            formatResult.formattedContent = successContent
             onFinished.captured.invoke(formatResult)
         }
 
@@ -96,11 +94,10 @@ class DprintFormattingTaskTest : FunSpec({
         val successContentPart1 = formattedPart1 + unformattedPart2
         val successContentPart2 = formattedPart1 + formattedPart2
 
-        val formatResult1 = FormatResult()
-        formatResult1.formattedContent = successContentPart1
+        val formatResult1 = FormatResult(formattedContent = successContentPart1)
         val onFinished1 = slot<(FormatResult) -> Unit>()
 
-        val formatResult2 = FormatResult()
+        val formatResult2 = FormatResult(formattedContent = successContentPart2)
         val onFinished2 = slot<(FormatResult) -> Unit>()
 
         every { formattingRequest.documentText } returns testContent
@@ -126,7 +123,6 @@ class DprintFormattingTaskTest : FunSpec({
                 2, path, successContentPart1, any(), any(), capture(onFinished2),
             )
         } answers {
-            formatResult2.formattedContent = successContentPart2
             onFinished2.captured.invoke(formatResult2)
         }
 
@@ -152,7 +148,7 @@ class DprintFormattingTaskTest : FunSpec({
     test("it calls editorServiceManager.cancel with the format id when cancelled") {
         val testContent = "val test =   \"test\""
         val formattedContent = "val test = \"test\""
-        val formatResult = FormatResult()
+        val formatResult = FormatResult(formattedContent = formattedContent)
         val onFinished = slot<(FormatResult) -> Unit>()
 
         mockkStatic("com.dprint.utils.LogUtilsKt")
@@ -172,7 +168,6 @@ class DprintFormattingTaskTest : FunSpec({
             CompletableFuture.runAsync {
                 dprintFormattingTask.cancel()
                 Thread.sleep(5000)
-                formatResult.formattedContent = formattedContent
                 onFinished.captured.invoke(formatResult)
             }
         }
@@ -188,7 +183,7 @@ class DprintFormattingTaskTest : FunSpec({
     test("it calls formattingRequest.onError when the format returns a failure state") {
         val testContent = "val test =   \"test\""
         val testFailure = "Test failure"
-        val formatResult = FormatResult()
+        val formatResult = FormatResult(error = testFailure)
         val onFinished = slot<(FormatResult) -> Unit>()
 
         every { formattingRequest.documentText } returns testContent
@@ -200,7 +195,6 @@ class DprintFormattingTaskTest : FunSpec({
                 1, path, testContent, 0, testContent.length, capture(onFinished),
             )
         } answers {
-            formatResult.error = testFailure
             onFinished.captured.invoke(formatResult)
         }
 


### PR DESCRIPTION
## Overview

This just transforms the `FormatResult` class into a data class as it is a better representation of what it is supposed to be used for.