### PR TITLE
Test editor service v5

### DIFF
--- a/src/main/kotlin/com/dprint/services/FormatterService.kt
+++ b/src/main/kotlin/com/dprint/services/FormatterService.kt
@@ -26,7 +26,7 @@ interface IFormatterService {
  */
 @Service(Service.Level.PROJECT)
 class FormatterService(project: Project) : IFormatterService {
-    private val delegate =
+    private val impl =
         FormatterServiceImpl(
             project,
             project.service<EditorServiceManager>(),
@@ -36,7 +36,7 @@ class FormatterService(project: Project) : IFormatterService {
         virtualFile: VirtualFile,
         document: Document,
     ) {
-        this.delegate.format(virtualFile, document)
+        this.impl.format(virtualFile, document)
     }
 }
 

--- a/src/main/kotlin/com/dprint/services/editorservice/EditorServiceManager.kt
+++ b/src/main/kotlin/com/dprint/services/editorservice/EditorServiceManager.kt
@@ -157,9 +157,13 @@ class EditorServiceManager(private val project: Project) {
         createTaskWithTimeout(
             DprintBundle.message("editor.service.manager.priming.can.format.cache", path),
         ) {
-            editorService?.canFormat(path) {
-                canFormatCache[path] = it
-                infoLogWithConsole("$path ${if (it) "can" else "cannot"} be formatted", project, LOGGER)
+            editorService?.canFormat(path) { canFormat ->
+                if (canFormat == null) {
+                    infoLogWithConsole("Unable to determine if $path can be formatted.", project, LOGGER)
+                } else {
+                    canFormatCache[path] = canFormat
+                    infoLogWithConsole("$path ${if (canFormat) "can" else "cannot"} be formatted", project, LOGGER)
+                }
             }
         }
     }

--- a/src/main/kotlin/com/dprint/services/editorservice/IEditorService.kt
+++ b/src/main/kotlin/com/dprint/services/editorservice/IEditorService.kt
@@ -19,7 +19,7 @@ interface IEditorService : Disposable {
      */
     fun canFormat(
         filePath: String,
-        onFinished: (Boolean) -> Unit,
+        onFinished: (Boolean?) -> Unit,
     )
 
     fun canRangeFormat(): Boolean
@@ -44,7 +44,7 @@ interface IEditorService : Disposable {
     /**
      * This runs dprint using the editor service with the supplied file path and content as stdin.
      * @param formatId The id of the message that is passed to the underlying editor service. This is exposed at this
-     * level so we can cancel requests if need be.
+     * level, so we can cancel requests if need be.
      * @param filePath The path of the file being formatted. This is needed so the correct dprint configuration file
      * located.
      * @param content The content of the file as a string. This is formatted via Dprint and returned via the result.

--- a/src/main/kotlin/com/dprint/services/editorservice/v4/EditorServiceV4.kt
+++ b/src/main/kotlin/com/dprint/services/editorservice/v4/EditorServiceV4.kt
@@ -43,7 +43,7 @@ class EditorServiceV4(private val project: Project) : IEditorService {
 
     override fun canFormat(
         filePath: String,
-        onFinished: (Boolean) -> Unit,
+        onFinished: (Boolean?) -> Unit,
     ) {
         infoLogWithConsole(DprintBundle.message("formatting.checking.can.format", filePath), project, LOGGER)
 

--- a/src/main/kotlin/com/dprint/services/editorservice/v5/EditorServiceV5.kt
+++ b/src/main/kotlin/com/dprint/services/editorservice/v5/EditorServiceV5.kt
@@ -33,7 +33,7 @@ class EditorServiceV5(val project: Project) : IEditorService {
 
     override fun canFormat(
         filePath: String,
-        onFinished: (Boolean) -> Unit,
+        onFinished: (Boolean?) -> Unit,
     ) {
         impl.canFormat(filePath, onFinished)
     }
@@ -122,7 +122,7 @@ class EditorServiceV5Impl(
 
     override fun canFormat(
         filePath: String,
-        onFinished: (Boolean) -> Unit,
+        onFinished: (Boolean?) -> Unit,
     ) {
         handleStaleMessages()
 
@@ -139,30 +139,33 @@ class EditorServiceV5Impl(
     }
 
     private fun handleCanFormatResult(
-        it: PendingMessages.Result,
-        onFinished: (Boolean) -> Unit,
+        result: PendingMessages.Result,
+        onFinished: (Boolean?) -> Unit,
         filePath: String,
     ) {
         when {
-            (it.type == MessageType.CanFormatResponse && it.data is Boolean) -> {
-                onFinished(it.data)
+            (result.type == MessageType.CanFormatResponse && result.data is Boolean) -> {
+                onFinished(result.data)
             }
-            (it.type == MessageType.ErrorResponse && it.data is String) -> {
+            (result.type == MessageType.ErrorResponse && result.data is String) -> {
                 infoLogWithConsole(
-                    DprintBundle.message("editor.service.format.check.failed", filePath, it.data),
+                    DprintBundle.message("editor.service.format.check.failed", filePath, result.data),
                     project,
                     LOGGER,
                 )
+                onFinished(null)
             }
-            (it.type === MessageType.Dropped) -> {
+            (result.type === MessageType.Dropped) -> {
                 // do nothing
+                onFinished(null)
             }
             else -> {
                 infoLogWithConsole(
-                    DprintBundle.message("editor.service.unsupported.message.type", it.type),
+                    DprintBundle.message("editor.service.unsupported.message.type", result.type),
                     project,
                     LOGGER,
                 )
+                onFinished(null)
             }
         }
     }

--- a/src/test/kotlin/com/dprint/services/editorservice/v5/EditorServiceV5ImplTest.kt
+++ b/src/test/kotlin/com/dprint/services/editorservice/v5/EditorServiceV5ImplTest.kt
@@ -1,11 +1,165 @@
 package com.dprint.services.editorservice.v5
 
+import com.dprint.services.editorservice.EditorProcess
+import com.dprint.services.editorservice.FormatResult
+import com.dprint.utils.infoLogWithConsole
+import com.dprint.utils.warnLogWithConsole
+import com.intellij.openapi.project.Project
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.shouldBe
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.verify
 
 class EditorServiceV5ImplTest : FunSpec({
 
-    test("canFormat") { }
+    mockkStatic(::infoLogWithConsole)
+    mockkStatic(::createNewMessage)
 
-    test("fmt") { }
+    val project = mockk<Project>()
+    val editorProcess = mockk<EditorProcess>()
+    val pendingMessages = mockk<PendingMessages>()
+
+    val editorServiceV5 = EditorServiceV5Impl(project, editorProcess, pendingMessages)
+
+    beforeEach {
+        every { infoLogWithConsole(any(), project, any()) } returns Unit
+        every { createNewMessage(any()) } answers {
+            Message(1, firstArg())
+        }
+        every { pendingMessages.hasStaleMessages() } returns false
+    }
+
+    afterEach {
+        clearAllMocks()
+    }
+
+    test("canFormat sends the correct message and stores a handler") {
+        val testFile = "/test/File.kt"
+        val onFinished = mockk<(Boolean?) -> Unit>()
+
+        every { editorProcess.writeBuffer(any()) } returns Unit
+        every { pendingMessages.store(any(), any()) } returns Unit
+        every { onFinished(any()) } returns Unit
+
+        editorServiceV5.canFormat(testFile, onFinished)
+
+        val expectedMessage = Message(1, MessageType.CanFormat)
+        expectedMessage.addString(testFile)
+
+        verify(exactly = 1) { pendingMessages.store(1, any()) }
+        verify(exactly = 1) { editorProcess.writeBuffer(expectedMessage.build()) }
+    }
+
+    test("canFormat's handler invokes onFinished with the result on success") {
+        val testFile = "/test/File.kt"
+        val onFinished = mockk<(Boolean?) -> Unit>()
+        val capturedHandler = slot<(PendingMessages.Result) -> Unit>()
+
+        every { editorProcess.writeBuffer(any()) } returns Unit
+        every { pendingMessages.store(any(), capture(capturedHandler)) } returns Unit
+        every { onFinished(any()) } returns Unit
+
+        editorServiceV5.canFormat(testFile, onFinished)
+        capturedHandler.captured(PendingMessages.Result(MessageType.CanFormatResponse, true))
+
+        verify(exactly = 1) { onFinished(true) }
+    }
+
+    test("canFormat's handler invokes onFinished with null on error") {
+        val testFile = "/test/File.kt"
+        val onFinished = mockk<(Boolean?) -> Unit>()
+        val capturedHandler = slot<(PendingMessages.Result) -> Unit>()
+
+        every { editorProcess.writeBuffer(any()) } returns Unit
+        every { pendingMessages.store(any(), capture(capturedHandler)) } returns Unit
+        every { onFinished(any()) } returns Unit
+
+        editorServiceV5.canFormat(testFile, onFinished)
+        capturedHandler.captured(PendingMessages.Result(MessageType.ErrorResponse, "error"))
+
+        verify(exactly = 1) { onFinished(null) }
+    }
+
+    test("fmt sends the correct message and stores a handler") {
+        val testFile = "/test/File.kt"
+        val testContent = "val test = \"test\""
+        val onFinished = mockk<(FormatResult) -> Unit>()
+
+        every { editorProcess.writeBuffer(any()) } returns Unit
+        every { pendingMessages.store(any(), any()) } returns Unit
+        every { onFinished(any()) } returns Unit
+
+        editorServiceV5.fmt(1, testFile, testContent, null, null, onFinished)
+
+        val expectedMessage = Message(1, MessageType.FormatFile)
+        // path
+        expectedMessage.addString(testFile)
+        // start position
+        expectedMessage.addInt(0)
+        // content length
+        expectedMessage.addInt(testContent.toByteArray().size)
+        // don't override config
+        expectedMessage.addInt(0)
+        // content
+        expectedMessage.addString(testContent)
+
+        verify(exactly = 1) { pendingMessages.store(1, any()) }
+        verify(exactly = 1) { editorProcess.writeBuffer(expectedMessage.build()) }
+    }
+
+    test("fmt's handler invokes onFinished with the new content on success") {
+        val testFile = "/test/File.kt"
+        val testContent = "val test =   \"test\""
+        val formattedContent = "val test = \"test\""
+        val onFinished = mockk<(FormatResult) -> Unit>()
+        val capturedHandler = slot<(PendingMessages.Result) -> Unit>()
+
+        every { editorProcess.writeBuffer(any()) } returns Unit
+        every { pendingMessages.store(any(), capture(capturedHandler)) } returns Unit
+        every { onFinished(any()) } returns Unit
+
+        editorServiceV5.fmt(1, testFile, testContent, null, null, onFinished)
+        capturedHandler.captured(PendingMessages.Result(MessageType.FormatFileResponse, formattedContent))
+
+        verify(exactly = 1) { onFinished(FormatResult(formattedContent = formattedContent)) }
+    }
+
+    test("fmt's handler invokes onFinished with the error on failure") {
+        val testFile = "/test/File.kt"
+        val testContent = "val test =   \"test\""
+        val testError = "test error"
+        val onFinished = mockk<(FormatResult) -> Unit>()
+        val capturedHandler = slot<(PendingMessages.Result) -> Unit>()
+
+        mockkStatic("com.dprint.utils.LogUtilsKt")
+
+        every { infoLogWithConsole(any(), project, any()) } returns Unit
+        every { warnLogWithConsole(any(), project, any()) } returns Unit
+        every { editorProcess.writeBuffer(any()) } returns Unit
+        every { pendingMessages.store(any(), capture(capturedHandler)) } returns Unit
+        every { onFinished(any()) } returns Unit
+
+        editorServiceV5.fmt(1, testFile, testContent, null, null, onFinished)
+        capturedHandler.captured(PendingMessages.Result(MessageType.ErrorResponse, testError))
+
+        verify(exactly = 1) { onFinished(FormatResult(error = testError)) }
+    }
+
+    test("Cancel format creates the correct message") {
+        val testId = 7
+
+        every { editorProcess.writeBuffer(any()) } returns Unit
+        every { pendingMessages.take(any()) } returns null
+
+        editorServiceV5.cancelFormat(testId)
+
+        val expectedMessage = Message(1, MessageType.CancelFormat)
+        expectedMessage.addInt(testId)
+
+        verify { pendingMessages.take(testId) }
+        verify { editorProcess.writeBuffer(expectedMessage.build()) }
+    }
 })

--- a/src/test/kotlin/com/dprint/services/editorservice/v5/EditorServiceV5ImplTest.kt
+++ b/src/test/kotlin/com/dprint/services/editorservice/v5/EditorServiceV5ImplTest.kt
@@ -1,0 +1,11 @@
+package com.dprint.services.editorservice.v5
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class EditorServiceV5ImplTest : FunSpec({
+
+    test("canFormat") { }
+
+    test("fmt") { }
+})

--- a/src/test/kotlin/com/dprint/services/editorservice/v5/MessageTest.kt
+++ b/src/test/kotlin/com/dprint/services/editorservice/v5/MessageTest.kt
@@ -5,8 +5,9 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import java.nio.ByteBuffer
 
-internal class MessageTest : FunSpec({
+val SUCCESS_MESSAGE = byteArrayOf(-1, -1, -1, -1)
 
+internal class MessageTest : FunSpec({
     test("It builds a string message") {
         val id = 1
         val type = MessageType.Active


### PR DESCRIPTION
## Overview

This adds tests for `EditorServiceV5` as well as splitting it up so it can be tested and introducing better handling for when can format fails.