### PR TITLE
Small refactor for editor service + initialisation test

### DIFF
--- a/src/main/kotlin/com/dprint/services/editorservice/process/StdErrListener.kt
+++ b/src/main/kotlin/com/dprint/services/editorservice/process/StdErrListener.kt
@@ -1,0 +1,34 @@
+package com.dprint.services.editorservice.process
+
+import com.dprint.utils.errorLogWithConsole
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.project.Project
+import java.nio.BufferUnderflowException
+
+private val LOGGER = logger<StdErrListener>()
+
+class StdErrListener(private val project: Project, private val process: Process) {
+    fun listen() {
+        while (true) {
+            if (Thread.interrupted()) {
+                return
+            }
+
+            try {
+                process.errorStream?.bufferedReader()?.readLine()?.let { error ->
+                    errorLogWithConsole("Dprint daemon ${process.pid()}: $error", project, LOGGER)
+                }
+            } catch (e: InterruptedException) {
+                LOGGER.info(e)
+                return
+            } catch (e: BufferUnderflowException) {
+                // Happens when the editor service is shut down while this thread is waiting to read output
+                LOGGER.info(e)
+                return
+            } catch (e: Exception) {
+                LOGGER.info(e)
+                return
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/dprint/services/editorservice/v4/EditorServiceV4.kt
+++ b/src/main/kotlin/com/dprint/services/editorservice/v4/EditorServiceV4.kt
@@ -2,9 +2,9 @@ package com.dprint.services.editorservice.v4
 
 import com.dprint.config.ProjectConfiguration
 import com.dprint.i18n.DprintBundle
-import com.dprint.services.editorservice.EditorProcess
 import com.dprint.services.editorservice.FormatResult
 import com.dprint.services.editorservice.IEditorService
+import com.dprint.services.editorservice.process.EditorProcess
 import com.dprint.utils.infoLogWithConsole
 import com.dprint.utils.warnLogWithConsole
 import com.intellij.openapi.components.Service

--- a/src/main/kotlin/com/dprint/services/editorservice/v4/EditorServiceV4.kt
+++ b/src/main/kotlin/com/dprint/services/editorservice/v4/EditorServiceV4.kt
@@ -1,6 +1,7 @@
 package com.dprint.services.editorservice.v4
 
 import com.dprint.config.ProjectConfiguration
+import com.dprint.config.UserConfiguration
 import com.dprint.i18n.DprintBundle
 import com.dprint.services.editorservice.FormatResult
 import com.dprint.services.editorservice.IEditorService
@@ -19,7 +20,7 @@ private val LOGGER = logger<EditorServiceV4>()
 
 @Service(Service.Level.PROJECT)
 class EditorServiceV4(private val project: Project) : IEditorService {
-    private var editorProcess = EditorProcess(project)
+    private var editorProcess = EditorProcess(project, project.service<UserConfiguration>())
 
     override fun initialiseEditorService() {
         // If not enabled we don't start the editor service

--- a/src/main/kotlin/com/dprint/services/editorservice/v5/EditorServiceV5.kt
+++ b/src/main/kotlin/com/dprint/services/editorservice/v5/EditorServiceV5.kt
@@ -223,15 +223,15 @@ class EditorServiceV5Impl(
         startIndex: Int?,
         endIndex: Int?,
         content: String,
-    ): Message {
-        val message = Message(formatId ?: getNextMessageId(), MessageType.FormatFile)
-        message.addString(filePath)
+    ): OutgoingMessage {
+        val outgoingMessage = OutgoingMessage(formatId ?: getNextMessageId(), MessageType.FormatFile)
+        outgoingMessage.addString(filePath)
         // TODO We need to properly handle string index to byte index here
-        message.addInt(startIndex ?: 0) // for range formatting add starting index
-        message.addInt(endIndex ?: content.encodeToByteArray().size) // add ending index
-        message.addInt(0) // Override config
-        message.addString(content)
-        return message
+        outgoingMessage.addInt(startIndex ?: 0) // for range formatting add starting index
+        outgoingMessage.addInt(endIndex ?: content.encodeToByteArray().size) // add ending index
+        outgoingMessage.addInt(0) // Override config
+        outgoingMessage.addString(content)
+        return outgoingMessage
     }
 
     private fun mapResultToFormatResult(

--- a/src/main/kotlin/com/dprint/services/editorservice/v5/EditorServiceV5.kt
+++ b/src/main/kotlin/com/dprint/services/editorservice/v5/EditorServiceV5.kt
@@ -1,9 +1,9 @@
 package com.dprint.services.editorservice.v5
 
 import com.dprint.i18n.DprintBundle
-import com.dprint.services.editorservice.EditorProcess
 import com.dprint.services.editorservice.FormatResult
 import com.dprint.services.editorservice.IEditorService
+import com.dprint.services.editorservice.process.EditorProcess
 import com.dprint.utils.errorLogWithConsole
 import com.dprint.utils.infoLogWithConsole
 import com.dprint.utils.warnLogWithConsole

--- a/src/main/kotlin/com/dprint/services/editorservice/v5/EditorServiceV5.kt
+++ b/src/main/kotlin/com/dprint/services/editorservice/v5/EditorServiceV5.kt
@@ -1,5 +1,6 @@
 package com.dprint.services.editorservice.v5
 
+import com.dprint.config.UserConfiguration
 import com.dprint.i18n.DprintBundle
 import com.dprint.services.editorservice.FormatResult
 import com.dprint.services.editorservice.IEditorService
@@ -8,6 +9,7 @@ import com.dprint.utils.errorLogWithConsole
 import com.dprint.utils.infoLogWithConsole
 import com.dprint.utils.warnLogWithConsole
 import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import kotlinx.coroutines.TimeoutCancellationException
@@ -21,7 +23,8 @@ private const val SHUTDOWN_TIMEOUT = 1000L
 
 @Service(Service.Level.PROJECT)
 class EditorServiceV5(val project: Project) : IEditorService {
-    private val impl = EditorServiceV5Impl(project, EditorProcess(project), PendingMessages())
+    private val impl =
+        EditorServiceV5Impl(project, EditorProcess(project, project.service<UserConfiguration>()), PendingMessages())
 
     override fun initialiseEditorService() {
         impl.initialiseEditorService()

--- a/src/main/kotlin/com/dprint/services/editorservice/v5/IncomingMessage.kt
+++ b/src/main/kotlin/com/dprint/services/editorservice/v5/IncomingMessage.kt
@@ -4,7 +4,7 @@ import java.nio.ByteBuffer
 
 private const val U32_BYTE_SIZE = 4
 
-class MessageBody(private val buffer: ByteArray) {
+class IncomingMessage(private val buffer: ByteArray) {
     private var index = 0
 
     fun readInt(): Int {

--- a/src/main/kotlin/com/dprint/services/editorservice/v5/OutgoingMessage.kt
+++ b/src/main/kotlin/com/dprint/services/editorservice/v5/OutgoingMessage.kt
@@ -7,15 +7,15 @@ import java.util.concurrent.atomic.AtomicInteger
 
 private var messageId = AtomicInteger(0)
 
-fun createNewMessage(type: MessageType): Message {
-    return Message(getNextMessageId(), type)
+fun createNewMessage(type: MessageType): OutgoingMessage {
+    return OutgoingMessage(getNextMessageId(), type)
 }
 
 fun getNextMessageId(): Int {
     return messageId.incrementAndGet()
 }
 
-class Message(val id: Int, private val type: MessageType) {
+class OutgoingMessage(val id: Int, private val type: MessageType) {
     // Dprint uses unsigned bytes of 4x255 for the success message and that translates
     // to 4x-1 in the jvm's signed bytes.
     private val successMessage = byteArrayOf(-1, -1, -1, -1)

--- a/src/main/kotlin/com/dprint/services/editorservice/v5/StdoutListener.kt
+++ b/src/main/kotlin/com/dprint/services/editorservice/v5/StdoutListener.kt
@@ -1,7 +1,7 @@
 package com.dprint.services.editorservice.v5
 
 import com.dprint.i18n.DprintBundle
-import com.dprint.services.editorservice.EditorProcess
+import com.dprint.services.editorservice.process.EditorProcess
 import com.intellij.openapi.diagnostic.logger
 import java.nio.BufferUnderflowException
 

--- a/src/main/kotlin/com/dprint/services/editorservice/v5/StdoutListener.kt
+++ b/src/main/kotlin/com/dprint/services/editorservice/v5/StdoutListener.kt
@@ -10,7 +10,6 @@ private const val SLEEP_TIME = 500L
 private val LOGGER = logger<StdoutListener>()
 
 class StdoutListener(private val editorProcess: EditorProcess, private val pendingMessages: PendingMessages) {
-    @Suppress("TooGenericExceptionCaught")
     fun listen() {
         LOGGER.info(DprintBundle.message("editor.service.started.stdout.listener"))
         while (true) {
@@ -37,7 +36,7 @@ class StdoutListener(private val editorProcess: EditorProcess, private val pendi
         val messageId = editorProcess.readInt()
         val messageType = editorProcess.readInt()
         val bodyLength = editorProcess.readInt()
-        val body = MessageBody(editorProcess.readBuffer(bodyLength))
+        val body = IncomingMessage(editorProcess.readBuffer(bodyLength))
         editorProcess.readAndAssertSuccess()
 
         when (messageType) {
@@ -102,7 +101,7 @@ class StdoutListener(private val editorProcess: EditorProcess, private val pendi
         sendResponse(message)
     }
 
-    private fun sendResponse(message: Message) {
-        editorProcess.writeBuffer(message.build())
+    private fun sendResponse(outgoingMessage: OutgoingMessage) {
+        editorProcess.writeBuffer(outgoingMessage.build())
     }
 }

--- a/src/test/kotlin/com/dprint/services/editorservice/process/EditorProcessTest.kt
+++ b/src/test/kotlin/com/dprint/services/editorservice/process/EditorProcessTest.kt
@@ -1,0 +1,82 @@
+package com.dprint.services.editorservice.process
+
+import com.dprint.config.UserConfiguration
+import com.dprint.utils.getValidConfigPath
+import com.dprint.utils.getValidExecutablePath
+import com.dprint.utils.infoLogWithConsole
+import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.openapi.project.Project
+import io.kotest.core.spec.style.FunSpec
+import io.mockk.EqMatcher
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkConstructor
+import io.mockk.mockkStatic
+import io.mockk.verify
+import java.io.File
+import java.util.concurrent.CompletableFuture
+
+class EditorProcessTest : FunSpec({
+    mockkStatic(ProcessHandle::current)
+    mockkStatic(::infoLogWithConsole)
+    mockkStatic("com.dprint.utils.FileUtilsKt")
+
+    val project = mockk<Project>()
+    val processHandle = mockk<ProcessHandle>()
+    val process = mockk<Process>()
+    val userConfig = mockk<UserConfiguration>()
+
+    val editorProcess = EditorProcess(project, userConfig)
+
+    beforeEach {
+        every { infoLogWithConsole(any(), project, any()) } returns Unit
+    }
+
+    afterEach {
+        clearAllMocks()
+    }
+
+    test("it creates a process with the correct args") {
+        val execPath = "/bin/dprint"
+        val configPath = "./dprint.json"
+        val workingDir = "/working/dir"
+        val parentProcessId = 1L
+
+        mockkConstructor(GeneralCommandLine::class)
+        mockkConstructor(File::class)
+        mockkConstructor(StdErrListener::class)
+
+        every { getValidExecutablePath(project) } returns execPath
+        every { getValidConfigPath(project) } returns configPath
+
+        every { ProcessHandle.current() } returns processHandle
+        every { processHandle.pid() } returns parentProcessId
+        every { userConfig.state } returns UserConfiguration.State()
+        every { constructedWith<File>(EqMatcher(configPath)).parent } returns workingDir
+        every { process.pid() } returns 2L
+        every { process.onExit() } returns CompletableFuture.completedFuture(process)
+        every { anyConstructed<StdErrListener>().listen() } returns Unit
+
+        val expectedArgs =
+            listOf(
+                execPath,
+                "editor-service",
+                "--config",
+                configPath,
+                "--parent-pid",
+                parentProcessId.toString(),
+                "--verbose",
+            )
+
+        // This essentially tests the correct args are passed in.
+        every { constructedWith<GeneralCommandLine>(EqMatcher(expectedArgs)).createProcess() } returns process
+
+        editorProcess.initialize()
+
+        verify(
+            exactly = 1,
+        ) { constructedWith<GeneralCommandLine>(EqMatcher(expectedArgs)).withWorkDirectory(workingDir) }
+        verify(exactly = 1) { constructedWith<GeneralCommandLine>(EqMatcher(expectedArgs)).createProcess() }
+    }
+})

--- a/src/test/kotlin/com/dprint/services/editorservice/v5/EditorServiceV5ImplTest.kt
+++ b/src/test/kotlin/com/dprint/services/editorservice/v5/EditorServiceV5ImplTest.kt
@@ -1,7 +1,7 @@
 package com.dprint.services.editorservice.v5
 
-import com.dprint.services.editorservice.EditorProcess
 import com.dprint.services.editorservice.FormatResult
+import com.dprint.services.editorservice.process.EditorProcess
 import com.dprint.utils.infoLogWithConsole
 import com.dprint.utils.warnLogWithConsole
 import com.intellij.openapi.project.Project

--- a/src/test/kotlin/com/dprint/services/editorservice/v5/EditorServiceV5ImplTest.kt
+++ b/src/test/kotlin/com/dprint/services/editorservice/v5/EditorServiceV5ImplTest.kt
@@ -27,7 +27,7 @@ class EditorServiceV5ImplTest : FunSpec({
     beforeEach {
         every { infoLogWithConsole(any(), project, any()) } returns Unit
         every { createNewMessage(any()) } answers {
-            Message(1, firstArg())
+            OutgoingMessage(1, firstArg())
         }
         every { pendingMessages.hasStaleMessages() } returns false
     }
@@ -46,11 +46,11 @@ class EditorServiceV5ImplTest : FunSpec({
 
         editorServiceV5.canFormat(testFile, onFinished)
 
-        val expectedMessage = Message(1, MessageType.CanFormat)
-        expectedMessage.addString(testFile)
+        val expectedOutgoingMessage = OutgoingMessage(1, MessageType.CanFormat)
+        expectedOutgoingMessage.addString(testFile)
 
         verify(exactly = 1) { pendingMessages.store(1, any()) }
-        verify(exactly = 1) { editorProcess.writeBuffer(expectedMessage.build()) }
+        verify(exactly = 1) { editorProcess.writeBuffer(expectedOutgoingMessage.build()) }
     }
 
     test("canFormat's handler invokes onFinished with the result on success") {
@@ -94,20 +94,20 @@ class EditorServiceV5ImplTest : FunSpec({
 
         editorServiceV5.fmt(1, testFile, testContent, null, null, onFinished)
 
-        val expectedMessage = Message(1, MessageType.FormatFile)
+        val expectedOutgoingMessage = OutgoingMessage(1, MessageType.FormatFile)
         // path
-        expectedMessage.addString(testFile)
+        expectedOutgoingMessage.addString(testFile)
         // start position
-        expectedMessage.addInt(0)
+        expectedOutgoingMessage.addInt(0)
         // content length
-        expectedMessage.addInt(testContent.toByteArray().size)
+        expectedOutgoingMessage.addInt(testContent.toByteArray().size)
         // don't override config
-        expectedMessage.addInt(0)
+        expectedOutgoingMessage.addInt(0)
         // content
-        expectedMessage.addString(testContent)
+        expectedOutgoingMessage.addString(testContent)
 
         verify(exactly = 1) { pendingMessages.store(1, any()) }
-        verify(exactly = 1) { editorProcess.writeBuffer(expectedMessage.build()) }
+        verify(exactly = 1) { editorProcess.writeBuffer(expectedOutgoingMessage.build()) }
     }
 
     test("fmt's handler invokes onFinished with the new content on success") {
@@ -156,10 +156,10 @@ class EditorServiceV5ImplTest : FunSpec({
 
         editorServiceV5.cancelFormat(testId)
 
-        val expectedMessage = Message(1, MessageType.CancelFormat)
-        expectedMessage.addInt(testId)
+        val expectedOutgoingMessage = OutgoingMessage(1, MessageType.CancelFormat)
+        expectedOutgoingMessage.addInt(testId)
 
         verify { pendingMessages.take(testId) }
-        verify { editorProcess.writeBuffer(expectedMessage.build()) }
+        verify { editorProcess.writeBuffer(expectedOutgoingMessage.build()) }
     }
 })

--- a/src/test/kotlin/com/dprint/services/editorservice/v5/MessageBodyTest.kt
+++ b/src/test/kotlin/com/dprint/services/editorservice/v5/MessageBodyTest.kt
@@ -9,8 +9,8 @@ class MessageBodyTest : FunSpec({
         val int = 7
         val buffer = ByteBuffer.allocate(4)
         buffer.putInt(7)
-        val messageBody = MessageBody(buffer.array())
-        messageBody.readInt() shouldBe int
+        val incomingMessage = IncomingMessage(buffer.array())
+        incomingMessage.readInt() shouldBe int
     }
 
     test("It decodes a string") {
@@ -22,7 +22,7 @@ class MessageBodyTest : FunSpec({
         // Need to call array here so the 0's get copied into the new buffer
         buffer.put(sizeBuffer.array())
         buffer.put(textAsByteArray)
-        val messageBody = MessageBody(buffer.array())
-        messageBody.readSizedString() shouldBe text
+        val incomingMessage = IncomingMessage(buffer.array())
+        incomingMessage.readSizedString() shouldBe text
     }
 })

--- a/src/test/kotlin/com/dprint/services/editorservice/v5/MessageTest.kt
+++ b/src/test/kotlin/com/dprint/services/editorservice/v5/MessageTest.kt
@@ -13,8 +13,8 @@ internal class MessageTest : FunSpec({
         val type = MessageType.Active
         val text = "blah!"
         val textAsBytes = text.toByteArray()
-        val message = Message(id, type)
-        message.addString(text)
+        val outgoingMessage = OutgoingMessage(id, type)
+        outgoingMessage.addString(text)
 
         // 4 is for the size of the part, it has a single part
         val bodyLength = 4 + text.length
@@ -28,15 +28,15 @@ internal class MessageTest : FunSpec({
         expected.put(textAsBytes)
         expected.put(SUCCESS_MESSAGE)
 
-        message.build() shouldBe expected.array()
+        outgoingMessage.build() shouldBe expected.array()
     }
 
     test("It builds an int message") {
         val id = 1
         val type = MessageType.Active
         val int = 2
-        val message = Message(id, type)
-        message.addInt(int)
+        val outgoingMessage = OutgoingMessage(id, type)
+        outgoingMessage.addInt(int)
 
         // id + message type + body size + part content + success message
         val expectedSize = 4 * 3 + 4 + SUCCESS_MESSAGE.size
@@ -47,7 +47,7 @@ internal class MessageTest : FunSpec({
         expected.put(createIntBytes(int))
         expected.put(SUCCESS_MESSAGE)
 
-        message.build() shouldBe expected.array()
+        outgoingMessage.build() shouldBe expected.array()
     }
 
     test("It builds a combined message") {
@@ -56,9 +56,9 @@ internal class MessageTest : FunSpec({
         val int = 2
         val text = "blah!"
         val textAsBytes = text.toByteArray()
-        val message = Message(id, type)
-        message.addInt(int)
-        message.addString(text)
+        val outgoingMessage = OutgoingMessage(id, type)
+        outgoingMessage.addInt(int)
+        outgoingMessage.addString(text)
 
         // body length
         val bodyLength = 4 + 4 + text.length
@@ -73,7 +73,7 @@ internal class MessageTest : FunSpec({
         expected.put(textAsBytes)
         expected.put(SUCCESS_MESSAGE)
 
-        message.build() shouldBe expected.array()
+        outgoingMessage.build() shouldBe expected.array()
     }
 })
 


### PR DESCRIPTION
## Overview

This refactors editor process to pull out the stderr listener (similar to the stdout listen in editor service v5), rename the messages to be more indicative of their purpose, and to write a test to lock in initialisation of the process