### PR TITLE
Better error handling when services disposed.

### DIFF
--- a/src/main/kotlin/com/dprint/services/editorservice/process/StdErrListener.kt
+++ b/src/main/kotlin/com/dprint/services/editorservice/process/StdErrListener.kt
@@ -4,31 +4,44 @@ import com.dprint.utils.errorLogWithConsole
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import java.nio.BufferUnderflowException
+import kotlin.concurrent.thread
 
 private val LOGGER = logger<StdErrListener>()
 
 class StdErrListener(private val project: Project, private val process: Process) {
-    fun listen() {
-        while (true) {
-            if (Thread.interrupted()) {
-                return
-            }
+    private var listenerThread: Thread? = null
+    private var disposing = false
 
-            try {
-                process.errorStream?.bufferedReader()?.readLine()?.let { error ->
-                    errorLogWithConsole("Dprint daemon ${process.pid()}: $error", project, LOGGER)
+    fun listen() {
+        disposing = false
+        listenerThread =
+            thread(start = true) {
+                while (true) {
+                    if (Thread.interrupted()) {
+                        return@thread
+                    }
+
+                    try {
+                        process.errorStream?.bufferedReader()?.readLine()?.let { error ->
+                            errorLogWithConsole("Dprint daemon ${process.pid()}: $error", project, LOGGER)
+                        }
+                    } catch (e: InterruptedException) {
+                        if (!disposing) LOGGER.info(e)
+                        return@thread
+                    } catch (e: BufferUnderflowException) {
+                        // Happens when the editor service is shut down while this thread is waiting to read output
+                        if (!disposing) LOGGER.info(e)
+                        return@thread
+                    } catch (e: Exception) {
+                        if (!disposing) LOGGER.info(e)
+                        return@thread
+                    }
                 }
-            } catch (e: InterruptedException) {
-                LOGGER.info(e)
-                return
-            } catch (e: BufferUnderflowException) {
-                // Happens when the editor service is shut down while this thread is waiting to read output
-                LOGGER.info(e)
-                return
-            } catch (e: Exception) {
-                LOGGER.info(e)
-                return
             }
-        }
+    }
+
+    fun dispose() {
+        disposing = true
+        listenerThread?.interrupt()
     }
 }


### PR DESCRIPTION
## Overview

Since raising the exception logging to be a little more aggressive there are race conditions that trigger errors when the plugin is being disposed. Namely, the stdout listener in the v5 editor service raises an error sometimes due to the stream being shut down which it is listening to.

This PR simply turns logging off while disposing of the plugin. I also pushed the threads into the listeners as it makes more sense to have the listeners control their own threading.