### PR TITLE
Show error notification when initialisation fails.

### DIFF
--- a/src/main/kotlin/com/dprint/listeners/ProjectStartupListener.kt
+++ b/src/main/kotlin/com/dprint/listeners/ProjectStartupListener.kt
@@ -1,6 +1,7 @@
 package com.dprint.listeners
 
 import com.dprint.services.editorservice.EditorServiceManager
+import com.dprint.toolwindow.Console
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.startup.ProjectActivity
@@ -8,6 +9,7 @@ import com.intellij.openapi.startup.ProjectActivity
 class ProjectStartupListener : ProjectActivity {
     override suspend fun execute(project: Project) {
         val editorServiceManager = project.service<EditorServiceManager>()
+        project.service<Console>()
         editorServiceManager.restartEditorService()
     }
 }

--- a/src/main/kotlin/com/dprint/toolwindow/Console.kt
+++ b/src/main/kotlin/com/dprint/toolwindow/Console.kt
@@ -3,11 +3,13 @@ package com.dprint.toolwindow
 import com.dprint.messages.DprintMessage
 import com.intellij.execution.impl.ConsoleViewImpl
 import com.intellij.execution.ui.ConsoleViewContentType
+import com.intellij.openapi.components.Service
 import com.intellij.openapi.project.Project
 import com.intellij.psi.search.GlobalSearchScope
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
+@Service(Service.Level.PROJECT)
 class Console(val project: Project) {
     val consoleView = ConsoleViewImpl(project, GlobalSearchScope.allScope(project), false, false)
 

--- a/src/main/kotlin/com/dprint/toolwindow/ConsoleToolWindowFactory.kt
+++ b/src/main/kotlin/com/dprint/toolwindow/ConsoleToolWindowFactory.kt
@@ -14,7 +14,7 @@ class ConsoleToolWindowFactory : ToolWindowFactory, DumbAware {
         project: Project,
         toolWindow: ToolWindow,
     ) {
-        val console = Console(project)
+        val console = project.service<Console>()
         val contentFactory = ContentFactory.getInstance()
         val panel = SimpleToolWindowPanel(true, false)
         panel.setContent(console.consoleView.component)

--- a/src/main/resources/messages/Bundle.properties
+++ b/src/main/resources/messages/Bundle.properties
@@ -48,6 +48,9 @@ editor.service.incorrect.message.size=Incorrect message size, expected {0} and g
 editor.service.initialize=Initializing {0}
 editor.service.manager.creating.formatting.task=Creating formatting task for {0}
 editor.service.manager.initialising.editor.service=Initialising editor service
+editor.service.manager.initialising.editor.service.failed.title=Dprint failed to initialise
+editor.service.manager.initialising.editor.service.failed.content=Please check the IDE errors and the dprint console \
+  tool window to diagnose the issue.
 editor.service.manager.no.cached.can.format=Did not find cached can format result for {0}
 editor.service.manager.priming.can.format.cache=Priming can format cache for {0}
 editor.service.manager.received.schema.version=Received schema version {0}


### PR DESCRIPTION
## Overview

This adds a notification to the UI when the editor service fails to start up.

Also, the console tool window will now start recording and showing output from project start up rather than from the first time the console is opened.

### Example

<img width="1328" alt="Screenshot 2024-01-16 at 8 47 15 pm" src="https://github.com/dprint/dprint-intellij/assets/7344652/07018e8d-5711-4fbf-a756-5c4bb9e0f403">
