### PR TITLE
Clear cached state when restarting from a failure

### DIFF
--- a/src/main/kotlin/com/dprint/listeners/FileOpenedListener.kt
+++ b/src/main/kotlin/com/dprint/listeners/FileOpenedListener.kt
@@ -19,7 +19,13 @@ class FileOpenedListener : FileEditorManagerListener {
     ) {
         super.fileOpened(source, file)
         val projectConfig = source.project.service<ProjectConfiguration>().state
-        if (!projectConfig.enabled) return
+        if (!projectConfig.enabled ||
+            !source.project.isOpen ||
+            !source.project.isInitialized ||
+            source.project.isDisposed
+        ) {
+            return
+        }
 
         // We ignore scratch files as they are never part of config
         if (!isFormattableFile(source.project, file)) return

--- a/src/main/kotlin/com/dprint/services/editorservice/EditorServiceManager.kt
+++ b/src/main/kotlin/com/dprint/services/editorservice/EditorServiceManager.kt
@@ -76,6 +76,16 @@ class EditorServiceManager(private val project: Project) {
     }
 
     /**
+     * In some cases we want to throw if the editor service is not available to ensure that a restart is actioned
+     * appropriately.
+     */
+    private fun getEditorService(): IEditorService {
+        return editorService ?: throw RuntimeException(
+            DprintBundle.message("editor.service.manager.not.initialised"),
+        )
+    }
+
+    /**
      * Gets a cached canFormat result. If a result doesn't exist this will return null and start a request to fill the
      * value in the cache.
      */
@@ -106,7 +116,7 @@ class EditorServiceManager(private val project: Project) {
             TaskInfo(TaskType.PrimeCanFormat, path, null),
             DprintBundle.message("editor.service.manager.priming.can.format.cache", path),
             {
-                editorService?.canFormat(path) { canFormat ->
+                getEditorService().canFormat(path) { canFormat ->
                     if (canFormat == null) {
                         infoLogWithConsole("Unable to determine if $path can be formatted.", project, LOGGER)
                     } else {
@@ -147,7 +157,7 @@ class EditorServiceManager(private val project: Project) {
         editorServiceTaskQueue.createTaskWithTimeout(
             TaskInfo(TaskType.Format, path, formatId),
             DprintBundle.message("editor.service.manager.creating.formatting.task", path),
-            { editorService?.fmt(formatId, path, content, startIndex, endIndex, onFinished) },
+            { getEditorService().fmt(formatId, path, content, startIndex, endIndex, onFinished) },
             TIMEOUT,
             {
                 onFinished(FormatResult())

--- a/src/main/kotlin/com/dprint/services/editorservice/EditorServiceManager.kt
+++ b/src/main/kotlin/com/dprint/services/editorservice/EditorServiceManager.kt
@@ -175,9 +175,7 @@ class EditorServiceManager(private val project: Project) {
                 }
             },
             TIMEOUT,
-            {
-                maybeInitialiseEditorService()
-            },
+            { restartEditorService() },
         )
     }
 
@@ -210,13 +208,14 @@ class EditorServiceManager(private val project: Project) {
             DprintBundle.message("editor.service.manager.creating.formatting.task", path),
             { editorService?.fmt(formatId, path, content, startIndex, endIndex, onFinished) },
             TIMEOUT,
-            { onFinished(FormatResult()) },
+            {
+                onFinished(FormatResult())
+                restartEditorService()
+            },
         )
     }
 
     fun restartEditorService() {
-        // TODO rather than restarting we should try and see if it is healthy, cancel the pending format, and drain
-        //  pending messages if we are on schema version 5
         maybeInitialiseEditorService()
         clearCanFormatCache()
         for (virtualFile in FileEditorManager.getInstance(project).openFiles) {

--- a/src/main/resources/messages/Bundle.properties
+++ b/src/main/resources/messages/Bundle.properties
@@ -52,6 +52,8 @@ editor.service.manager.initialising.editor.service=Initialising editor service
 editor.service.manager.initialising.editor.service.failed.title=Dprint failed to initialise
 editor.service.manager.initialising.editor.service.failed.content=Please check the IDE errors and the dprint console \
   tool window to diagnose the issue.
+editor.service.manager.not.initialised=Editor Service is not initialised. Please check your environment and restart \
+  the dprint plugin.
 editor.service.manager.no.cached.can.format=Did not find cached can format result for {0}
 editor.service.manager.priming.can.format.cache=Priming can format cache for {0}
 editor.service.manager.received.schema.version=Received schema version {0}


### PR DESCRIPTION
## Overview

In the spirit of getting back to a health state, this PR makes the plugin clears the cached file status after a failed restart and adds some more logging to make it more identifiable.