### PR TITLE
Update plugin name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 <!-- Keep a Changelog guide -> https://keepachangelog.com -->
 
-# dprint-intellij-plugin Changelog
+# dprint Changelog
 
 ## [Unreleased]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## [Unreleased]
 
+- Update plugin name for marketplace verification
+
 ## 0.8.1 - 2024-12-06
 
 - Reinstate require restart, even though the plugin doesn't technically need it, it avoids issues that a restart would

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# dprint-intellij-plugin
+# dprint
 
 <!-- Plugin description -->
 This plugin adds support for dprint, a flexible and extensible code formatter ([dprint.dev](https://dprint.dev/)). It is

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -106,7 +106,7 @@ intellijPlatform {
     }
 
     pluginVerification {
-        freeArgs = listOf("-mute", "TemplateWordInPluginId,TemplateWordInPluginName")
+        freeArgs = listOf("-mute", "TemplateWordInPluginId")
         ides {
             select {
                 types =

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # IntelliJ Platform Artifacts Repositories
 # -> https://plugins.jetbrains.com/docs/intellij/intellij-artifacts.html
 pluginGroup=com.dprint.intellij.plugin
-pluginName=dprint-intellij-plugin
+pluginName=dprint
 pluginVersion=0.8.1
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # -> https://plugins.jetbrains.com/docs/intellij/intellij-artifacts.html
 pluginGroup=com.dprint.intellij.plugin
 pluginName=dprint
-pluginVersion=0.8.1
+pluginVersion=0.8.2
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild=241

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version "0.7.0"
 }
 
-rootProject.name = "dprint-intellij-plugin"
+rootProject.name = "dprint"


### PR DESCRIPTION
## Overview

We are seeing issues where the plugin isn't releasing due to some validation on the IJ marketplace. This PR updates the name as per the email David received and I am verifying that we don't need to change the plugin id on the IJ slack atm.

Fixes #101