### PR TITLE
enable FORMAT_FRAGMENTS feature

### DIFF
--- a/src/main/kotlin/com/dprint/formatter/DprintExternalFormatter.kt
+++ b/src/main/kotlin/com/dprint/formatter/DprintExternalFormatter.kt
@@ -30,8 +30,7 @@ private const val NAME = "dprintfmt"
  */
 class DprintExternalFormatter : AsyncDocumentFormattingService() {
     override fun getFeatures(): MutableSet<FormattingService.Feature> {
-        // When range formatting is available we need to specify format fragments here.
-        return mutableSetOf()
+        return mutableSetOf(FormattingService.Feature.FORMAT_FRAGMENTS)
     }
 
     override fun canFormat(file: PsiFile): Boolean {
@@ -85,6 +84,7 @@ class DprintExternalFormatter : AsyncDocumentFormattingService() {
         }
 
         if (!editorServiceManager.canRangeFormat() && isRangeFormat(formattingRequest)) {
+            // When range formatting is available we need to add support here.
             infoLogWithConsole(DprintBundle.message("external.formatter.range.formatting"), project, LOGGER)
             return null
         }


### PR DESCRIPTION
IntelliJ determines whether to delegate formatting tasks to a `FormattingService` based on the advertised features: https://github.com/JetBrains/intellij-community/blob/idea/251.25410.129/platform/code-style-api/src/com/intellij/formatting/service/FormattingService.java#L49

The Dprint plugin currently returns an empty list, indicating that only entire file formatting is supported. This means that when attempting to range format in IntelliJ, the Dprint plugin won't even be invoked, and the default IntelliJ formatter will be called, leading to an inconsistent formatting experience.

This PR enables the `com.intellij.formatting.service.FormattingService.Feature#FORMAT_FRAGMENTS` so that IntelliJ tries to use the dprint plugin for range formats.

This allows [this code path](https://github.com/dprint/dprint-intellij/blob/main/src/main/kotlin/com/dprint/formatter/DprintExternalFormatter.kt#L87-L90) to happen, instead of automatically delegating to the default IntelliJ formatter.

Note: This does _not_ add support for range formatting, it simply prevents the IntelliJ formatter from being run, and emits the intended log message.