### PR TITLE
Add configuration for force a full file format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## [Unreleased]
 
+- Add a config option to force a full file format even when range formatting has been selected. This was necessary to
+  enable desired behaviour on codebases that are fully CI enforced for formatting.
+
 ## 0.8.3 - 2025-06-07
 
 - While range formatting is not currently available, allow format fragment flows to come through so logging occurs.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -162,6 +162,7 @@ tasks {
 
     runIde {
         jvmArgs("-Xmx4098m")
+        autoReload = true
     }
 
     wrapper {

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # -> https://plugins.jetbrains.com/docs/intellij/intellij-artifacts.html
 pluginGroup=com.dprint.intellij.plugin
 pluginName=dprint
-pluginVersion=0.8.3
+pluginVersion=0.9.0
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild=241

--- a/src/main/kotlin/com/dprint/config/DprintConfigurable.kt
+++ b/src/main/kotlin/com/dprint/config/DprintConfigurable.kt
@@ -80,6 +80,18 @@ class DprintConfigurable(private val project: Project) : BoundSearchableConfigur
                     .comment(DprintBundle.message("config.override.intellij.formatter.description"))
             }
 
+            // Force overriding range formatting with whole file
+            row {
+                checkBox(DprintBundle.message("config.override.intellij.formatter.force.full.file.format"))
+                    .bindSelected(
+                        { projectConfig.state.forceFullFileFormat },
+                        { projectConfig.state.forceFullFileFormat = it },
+                    )
+                    .comment(
+                        DprintBundle.message("config.override.intellij.formatter.force.full.file.format.description"),
+                    )
+            }
+
             // Verbose logging checkbox
             row {
                 checkBox(DprintBundle.message("config.verbose.logging"))

--- a/src/main/kotlin/com/dprint/config/ProjectConfiguration.kt
+++ b/src/main/kotlin/com/dprint/config/ProjectConfiguration.kt
@@ -17,6 +17,7 @@ class ProjectConfiguration : PersistentStateComponent<ProjectConfiguration.State
         var executableLocation: String = ""
         var initialisationTimeout: Long = 10_000
         var commandTimeout: Long = 5_000
+        var forceFullFileFormat: Boolean = false
     }
 
     private var internalState = State()

--- a/src/main/kotlin/com/dprint/formatter/DprintExternalFormatter.kt
+++ b/src/main/kotlin/com/dprint/formatter/DprintExternalFormatter.kt
@@ -74,7 +74,7 @@ class DprintExternalFormatter : AsyncDocumentFormattingService() {
 
     override fun createFormattingTask(formattingRequest: AsyncFormattingRequest): FormattingTask? {
         val project = formattingRequest.context.project
-
+        val projectConfig = project.service<ProjectConfiguration>().state
         val editorServiceManager = project.service<EditorServiceManager>()
         val path = formattingRequest.ioFile?.path
 
@@ -83,7 +83,11 @@ class DprintExternalFormatter : AsyncDocumentFormattingService() {
             return null
         }
 
-        if (!editorServiceManager.canRangeFormat() && isRangeFormat(formattingRequest)) {
+        // TODO (ryanr) remove the range formatting from the manager, it hasn't been enabled in years.
+        if (!editorServiceManager.canRangeFormat() &&
+            isRangeFormat(formattingRequest) &&
+            !projectConfig.forceFullFileFormat
+        ) {
             // When range formatting is available we need to add support here.
             infoLogWithConsole(DprintBundle.message("external.formatter.range.formatting"), project, LOGGER)
             return null

--- a/src/main/resources/messages/Bundle.properties
+++ b/src/main/resources/messages/Bundle.properties
@@ -32,6 +32,9 @@ config.enable.description=Enables or disabled dprint for the project. Overrides 
 config.override.intellij.formatter=Default formatter override
 config.override.intellij.formatter.description=If enabled, dprint will replace the default IntelliJ formatter if the \
   file can be formatted by dprint. If the file cannot be formatted by dprint the IntelliJ formatter will run as per usual.
+config.override.intellij.formatter.force.full.file.format=Force full file format
+config.override.intellij.formatter.force.full.file.format.description=If enabled, dprint will format the entire file even when \
+   range formatting is selected. If unselected, no formatting will happen if a range is selected.
 config.name=Dprint
 config.reload=Restart
 config.reload.description=Restarts the dprint daemon process. Can also be triggered via the Restart dprint action.


### PR DESCRIPTION
## Overview

We have had an org user that has run into issues due to the FORMAT_FRAGMENTS behaviour that was recently enabled but ignored.

This PR adds project configuration to allow full file formats to happen even if the user is trying to range format. Realistically, once you have opted in your codebase to CI formatting, full file formatting vs range formatting is a moot point.

Also, because we haven't actually used range formatting at all even though the API has options for it but was never fully implemented i am removing it to take away possible causes for confusion. I will properly remove it all in https://github.com/dprint/dprint-intellij/pull/106 where I am fully changing the service structure and how it behaves.